### PR TITLE
Fix xGroup resource (add and remove user) when group has orphaned SIDs

### DIFF
--- a/DSCResources/MSFT_xGroupResource/MSFT_xGroupResource.psm1
+++ b/DSCResources/MSFT_xGroupResource/MSFT_xGroupResource.psm1
@@ -2465,7 +2465,9 @@ function Add-GroupMember
         $MemberAsPrincipal
     )
 
-    $Group.Members.Add($MemberAsPrincipal)
+    [System.DirectoryServices.DirectoryEntry]$groupDE = $Group.GetUnderlyingObject();
+    $nativeGroup = $groupDE.NativeObject;
+    $nativeGroup.Add("WinNT://" + $MemberAsPrincipal.Sid.Value);
 }
 
 <#
@@ -2495,7 +2497,9 @@ function Remove-GroupMember
         $MemberAsPrincipal
     )
 
-    $Group.Members.Remove($MemberAsPrincipal)
+    [System.DirectoryServices.DirectoryEntry]$groupDE = $Group.GetUnderlyingObject();
+    $nativeGroup = $groupDE.NativeObject;
+    $nativeGroup.Remove("WinNT://" + $MemberAsPrincipal.Sid.Value);
 }
 
 <#


### PR DESCRIPTION
FIX: Unable to add/remove objects to group due to orphaned SIDs: PrincipalOperationException: An error (1332) occurred
Except for the cases when a local group contains some orphaned SIDs (Active Directory users or groups that are already deleted).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xpsdesiredstateconfiguration/328)
<!-- Reviewable:end -->
