### PR TITLE
Added support for **delvals

### DIFF
--- a/DSCResources/MSFT_xRegistryResource/MSFT_xRegistryResource.psm1
+++ b/DSCResources/MSFT_xRegistryResource/MSFT_xRegistryResource.psm1
@@ -253,7 +253,7 @@ function Set-TargetResource
     {
         Write-Verbose -Message ($script:localizedData.RegistryKeyExists -f $Key)
 
-        $valueNameSpecified = ((-not [String]::IsNullOrEmpty($ValueName)) -and $ValueName -match "\*\*delval") -or $PSBoundParameters.ContainsKey('ValueType') -or $PSBoundParameters.ContainsKey('ValueData')
+        $valueNameSpecified = ((-not [String]::IsNullOrEmpty($ValueName)) -and $ValueName -notmatch "\*\*delval") -or $PSBoundParameters.ContainsKey('ValueType') -or $PSBoundParameters.ContainsKey('ValueData')
 
         # Check if the user wants to set a registry key value
         if ($valueNameSpecified)
@@ -341,7 +341,7 @@ function Set-TargetResource
                 if ($ValueName -match "\*\*delval")
                 {
                     Write-Verbose -Message ($script:localizedData.RemovingAllRegistryKeyValues -f $Key)
-                    Remove-ItemProperty -Path .\ -Name *
+                    Remove-ItemProperty -Path $key -Name *
                 }
                 else
                 {
@@ -464,7 +464,7 @@ function Test-TargetResource
     $registryResource = Get-TargetResource @getTargetResourceParameters
 
     # Check if the user specified a value name to retrieve
-    $valueNameSpecified = ((-not [String]::IsNullOrEmpty($ValueName)) -and $ValueName -match "\*\*delval") -or $PSBoundParameters.ContainsKey('ValueData')
+    $valueNameSpecified = ((-not [String]::IsNullOrEmpty($ValueName)) -and $ValueName -notmatch "\*\*delval") -or $PSBoundParameters.ContainsKey('ValueType') -or $PSBoundParameters.ContainsKey('ValueData')
 
     if ($valueNameSpecified)
     {

--- a/DSCResources/MSFT_xRegistryResource/en-US/MSFT_xRegistryResource.strings.psd1
+++ b/DSCResources/MSFT_xRegistryResource/en-US/MSFT_xRegistryResource.strings.psd1
@@ -35,4 +35,8 @@ ConvertFrom-StringData @'
     InvalidRegistryDrive = The registry drive {0} is invalid. Please update the Key parameter to include a valid registry drive.
     InvalidRegistryDriveAbbreviation = The registry drive abbreviation {0} is invalid. Please update the Key parameter to include a valid registry drive.
     RegistryDriveCouldNotBeMounted = The registry drive with the abbreviation {0} could not be mounted.
+    DelValsSpecified = **delvals specified! Determinme if any Values exist under key {0}.
+    RemovingAllRegistryValues = **delvals specified Remove All Registry Values for key {0}.
+    ValueNamesDoNotExist = Registry Key {0} has no ValueNames.
+    ValueNamesExist = Registry Key {0} has ValueNames.
 '@

--- a/DSCResources/MSFT_xRegistryResource/en-US/MSFT_xRegistryResource.strings.psd1
+++ b/DSCResources/MSFT_xRegistryResource/en-US/MSFT_xRegistryResource.strings.psd1
@@ -36,7 +36,7 @@ ConvertFrom-StringData @'
     InvalidRegistryDriveAbbreviation = The registry drive abbreviation {0} is invalid. Please update the Key parameter to include a valid registry drive.
     RegistryDriveCouldNotBeMounted = The registry drive with the abbreviation {0} could not be mounted.
     DelValsSpecified = **delvals specified! Determinme if any Values exist under key {0}.
-    RemovingAllRegistryValues = **delvals specified Remove All Registry Values for key {0}.
+    RemovingAllRegistryKeyValues = **delvals specified Remove All Registry Values for key {0}.
     ValueNamesDoNotExist = Registry Key {0} has no ValueNames.
     ValueNamesExist = Registry Key {0} has ValueNames.
 '@

--- a/Tests/Unit/MSFT_xRegistryResource.Tests.ps1
+++ b/Tests/Unit/MSFT_xRegistryResource.Tests.ps1
@@ -334,10 +334,10 @@ try
             $testRegistryKeyValueNames = "One", "Two", "Three"
             Mock -CommandName 'Get-RegistryKeyValueNames' -MockWith { return $testRegistryKeyValueNames }
             
-            Context 'ValueName specified was **delval' {
+            Context 'ValueName specified was **delvals' {
                 $getTargetResourceParameters = @{
                     Key = 'TestRegistryKey'
-                    ValueName = '**delval'
+                    ValueName = '**delvals'
                 }
                 
                 It 'Should not throw' {
@@ -671,6 +671,7 @@ try
             }
 
             Context '**delvals specified with Ensure -eq Absent' {
+                Mock -CommandName 'Get-RegistryKey' -MockWith { return $script:testRegistryKey }
                 $setTargetResourceParameters = @{
                     Key = 'TestRegistryKey'
                     ValueName = '**delvals'
@@ -731,7 +732,7 @@ try
                 }
 
                 It 'Should remove all registry key values' {
-                    Assert-MockCalled -CommandName 'Remove-ItemProperty' -Times 2 -Scope 'Context'
+                    Assert-MockCalled -CommandName 'Remove-ItemProperty' -Times 1 -Scope 'Context'
                 }
 
                 It 'Should not return' {

--- a/Tests/Unit/MSFT_xRegistryResource.Tests.ps1
+++ b/Tests/Unit/MSFT_xRegistryResource.Tests.ps1
@@ -268,16 +268,7 @@ try
                     Assert-MockCalled -CommandName 'Get-RegistryKey' -ParameterFilter $getRegistryKeyParameterFilter -Times 1 -Scope 'Context'
                 }
 
-                It 'Should retrieve the registry key value display name' {
-                    $getRegistryKeyValueDisplayNameParameterFilter = {
-                        $registryKeyValueNameParameterCorrect = $RegistryKeyValueName -eq $getTargetResourceParameters.ValueName
-                        return $registryKeyValueNameParameterCorrect
-                    }
-
-                    Assert-MockCalled -CommandName 'Get-RegistryKeyValueDisplayName' -ParameterFilter $getRegistryKeyValueDisplayNameParameterFilter -Times 1 -Scope 'Context'
-                }
-
-                It 'Should retrieve the registry key value' {
+                It 'Should retrieve the registry key value names' {
                     $getRegistryKeyValueParameterFilter = {
                         $registryKeyParameterCorrect = $null -eq (Compare-Object -ReferenceObject $script:testRegistryKey -DifferenceObject $RegistryKey)
                         $registryKeyValueNameParameterCorrect = $RegistryKeyValueName -eq $getTargetResourceParameters.ValueName
@@ -337,6 +328,57 @@ try
 
                 It 'Should return the ValueData property as the retrieved value' {
                     $getTargetResourceResult.ValueData | Should Be $testRegistryKeyValue
+                }
+            }
+
+            $testRegistryKeyValueNames = "One", "Two", "Three"
+            Mock -CommandName 'Get-RegistryKeyValueNames' -MockWith { return $testRegistryKeyValueNames }
+            
+            Context 'ValueName specified was **delval' {
+                $getTargetResourceParameters = @{
+                    Key = 'TestRegistryKey'
+                    ValueName = '**delval'
+                }
+                
+                It 'Should not throw' {
+                    { $null = Get-TargetResource @getTargetResourceParameters } | Should Not Throw
+                }
+
+                It 'Should retrieve the registry key' {
+                    $getRegistryKeyParameterFilter = {
+                        $registryKeyPathParameterCorrect = $RegistryKeyPath -eq $getTargetResourceParameters.Key
+                        return $registryKeyPathParameterCorrect
+                    }
+
+                    Assert-MockCalled -CommandName 'Get-RegistryKey' -ParameterFilter $getRegistryKeyParameterFilter -Times 1 -Scope 'Context'
+                }
+
+                It 'Should retrieve the registry key value names' {
+                    $getRegistryKeyValueParameterFilter = {
+                        $registryKeyParameterCorrect = $null -eq (Compare-Object -ReferenceObject $script:testRegistryKey -DifferenceObject $RegistryKey)
+                        
+                        return $registryKeyParameterCorrect
+                    }
+
+                    Assert-MockCalled -CommandName 'Get-RegistryKeyValueNames' -ParameterFilter $getRegistryKeyValueParameterFilter -Times 1 -Scope 'Context'
+                }
+
+                $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+
+                It 'Should return a hashtable' {
+                    $getTargetResourceResult -is [Hashtable] | Should Be $true
+                }
+
+                It 'Should return 5 hashtable properties' {
+                    $getTargetResourceResult.Keys.Count | Should Be 5
+                }
+
+                It 'Should return the Key property as the given registry key path' {
+                    $getTargetResourceResult.Key | Should Be $getTargetResourceParameters.Key
+                }
+
+                It 'Should return the Ensure property as Present' {
+                    $getTargetResourceResult.Ensure | Should Be 'Present'
                 }
             }
 
@@ -621,6 +663,75 @@ try
 
                 It 'Should not attempt to remove the registry key' {
                     Assert-MockCalled -CommandName 'Remove-Item' -Times 0 -Scope 'Context'
+                }
+
+                It 'Should not return' {
+                    Set-TargetResource @setTargetResourceParameters | Should Be $null
+                }
+            }
+
+            Context '**delvals specified with Ensure -eq Absent' {
+                $setTargetResourceParameters = @{
+                    Key = 'TestRegistryKey'
+                    ValueName = '**delvals'
+                    Ensure = 'Absent'
+                }
+
+                It 'Should not throw' {
+                    { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
+                }
+
+                It 'Should retrieve the registry key' {
+                    $getRegistryKeyParameterFilter = {
+                        $registryKeyPathParameterCorrect = $RegistryKeyPath -eq $setTargetResourceParameters.Key
+                        return $registryKeyPathParameterCorrect
+                    }
+
+                    Assert-MockCalled -CommandName 'Get-RegistryKey' -ParameterFilter $getRegistryKeyParameterFilter -Times 1 -Scope 'Context'
+                }
+
+                It 'Should not attempt to retrieve the registry key value display name' {
+                    Assert-MockCalled -CommandName 'Get-RegistryKeyValueDisplayName' -Times 0 -Scope 'Context'
+                }
+
+                It 'Should not attempt to retrieve the registry key value' {
+                    Assert-MockCalled -CommandName 'Get-RegistryKeyValue' -Times 0 -Scope 'Context'
+                }
+
+                It 'Should not attempt to convert the specified registry key value to a string' {
+                    Assert-MockCalled -CommandName 'ConvertTo-String' -Times 0 -Scope 'Context'
+                }
+
+                It 'Should not attempt to convert the specified registry key value to binary data' {
+                    Assert-MockCalled -CommandName 'ConvertTo-Binary' -Times 0 -Scope 'Context'
+                }
+
+                It 'Should not attempt to convert the specified registry key value to a dword' {
+                    Assert-MockCalled -CommandName 'ConvertTo-Dword' -Times 0 -Scope 'Context'
+                }
+
+                It 'Should not attempt to convert the specified registry key value to a qword' {
+                    Assert-MockCalled -CommandName 'ConvertTo-Qword' -Times 0 -Scope 'Context'
+                }
+
+                It 'Should not attempt to convert the specified registry key value to a multi-string' {
+                    Assert-MockCalled -CommandName 'ConvertTo-MultiString' -Times 0 -Scope 'Context'
+                }
+
+                It 'Should not attempt to test if the specified registry key value matches the retrieved registry key value' {
+                    Assert-MockCalled -CommandName 'Test-RegistryKeyValuesMatch' -Times 0 -Scope 'Context'
+                }
+
+                It 'Should not attempt to retrieve the registry key name' {
+                    Assert-MockCalled -CommandName 'Get-RegistryKeyName' -Times 0 -Scope 'Context'
+                }
+
+                It 'Should not attempt to set the registry key value' {
+                    Assert-MockCalled -CommandName 'Set-RegistryKeyValue' -Times 0 -Scope 'Context'
+                }
+
+                It 'Should remove all registry key values' {
+                    Assert-MockCalled -CommandName 'Remove-ItemProperty' -Times 2 -Scope 'Context'
                 }
 
                 It 'Should not return' {
@@ -1886,6 +1997,98 @@ try
                         $valueNameParameterCorrect = $ValueName -eq $testTargetResourceParameters.ValueName
 
                         return $keyParameterCorrect -and $valueNameParameterCorrect
+                    }
+
+                    Assert-MockCalled -CommandName 'Get-TargetResource' -ParameterFilter $getTargetResourceParameterFilter -Times 1 -Scope 'Context'
+                }
+
+                It 'Should not attempt to retrieve the registry key value display name' {
+                    Assert-MockCalled -CommandName 'Get-RegistryKeyValueDisplayName' -Times 0 -Scope 'Context'
+                }
+
+                It 'Should not attempt to test if the specified registry key value matches the retrieved registry key value' {
+                    Assert-MockCalled -CommandName 'Test-RegistryKeyValuesMatch' -Times 0 -Scope 'Context'
+                }
+
+                $testTargetResourceResult = Test-TargetResource @testTargetResourceParameters
+
+                It 'Should return a boolean' {
+                    $testTargetResourceResult -is [Boolean] | Should Be $true
+                }
+
+                It 'Should return True' {
+                    $testTargetResourceResult | Should Be $true
+                }
+            }
+
+            Context '**delvals specified and ValueNames are present' {
+                Mock -CommandName 'Get-TargetResource' -MockWith {
+                    return @{
+                        Ensure = 'Present'
+                    }
+                }
+
+                $testTargetResourceParameters = @{
+                    Key = 'TestRegistryKey'
+                    ValueName = '**delvals'
+                    Ensure = 'Absent'
+                }
+
+                It 'Should not throw' {
+                    { $null = Test-TargetResource @testTargetResourceParameters } | Should Not Throw
+                }
+
+                It 'Should retrieve the registry resource with the specified reigstry key' {
+                    $getTargetResourceParameterFilter = {
+                        $keyParameterCorrect = $Key -eq $testTargetResourceParameters.Key
+                        
+                        return $keyParameterCorrect
+                    }
+
+                    Assert-MockCalled -CommandName 'Get-TargetResource' -ParameterFilter $getTargetResourceParameterFilter -Times 1 -Scope 'Context'
+                }
+
+                It 'Should not attempt to retrieve the registry key value display name' {
+                    Assert-MockCalled -CommandName 'Get-RegistryKeyValueDisplayName' -Times 0 -Scope 'Context'
+                }
+
+                It 'Should not attempt to test if the specified registry key value matches the retrieved registry key value' {
+                    Assert-MockCalled -CommandName 'Test-RegistryKeyValuesMatch' -Times 0 -Scope 'Context'
+                }
+
+                $testTargetResourceResult = Test-TargetResource @testTargetResourceParameters
+
+                It 'Should return a boolean' {
+                    $testTargetResourceResult -is [Boolean] | Should Be $true
+                }
+
+                It 'Should return False' {
+                    $testTargetResourceResult | Should Be $false
+                }
+            }
+
+            Context '**delvals specified and ValueNames are absent' {
+                Mock -CommandName 'Get-TargetResource' -MockWith {
+                    return @{
+                        Ensure = 'Absent'
+                    }
+                }
+
+                $testTargetResourceParameters = @{
+                    Key = 'TestRegistryKey'
+                    ValueName = '**delvals'
+                    Ensure = 'Absent'
+                }
+
+                It 'Should not throw' {
+                    { $null = Test-TargetResource @testTargetResourceParameters } | Should Not Throw
+                }
+
+                It 'Should retrieve the registry resource with the specified registry key' {
+                    $getTargetResourceParameterFilter = {
+                        $keyParameterCorrect = $Key -eq $testTargetResourceParameters.Key
+                        
+                        return $keyParameterCorrect
                     }
 
                     Assert-MockCalled -CommandName 'Get-TargetResource' -ParameterFilter $getTargetResourceParameterFilter -Times 1 -Scope 'Context'


### PR DESCRIPTION
I have added support to specify the following to remove ALL Values under a given key (non-recursively) while leaving subkeys alone. (This is in accordance with https://msdn.microsoft.com/en-us/library/aa374407(v=vs.85).aspx)

This is the only Pol value (besides SecureKey) that is unsupported by the current implementation.
Specify
Registry Test
{
          Key = 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment\TestKey2'
          ValueName = "**delvals. " # The Syntax just looks for (**delvals), but this is the exact string parsed by Policy Parsers.
          Ensure = "Absent"
}

All Pester Tests have been created and validated. Also, as with using this resource to delete a key, the ValueType and ValueData should NOT be specified when using this key.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xpsdesiredstateconfiguration/345)
<!-- Reviewable:end -->
