### PR TITLE
[xRegistry] Set-TargetResource does not determine the type of registry value correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 - Corrected minor style issues.
 - Fix minor style issues in hashtable layout.
 - Added support for Checksum on xRemoteFile - [issue #423](https://github.com/PowerShell/PSDscResources/issues/423)
+- MSFT_xRegistryResource
+  - Fixes issue that the `Set-TargetResource` does not determine the type of registry value correctly. - [issue #436](https://github.com/dsccommunity/xPSDesiredStateConfiguration/issues/436)
 
 ## 8.10.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@
 - Fix minor style issues in hashtable layout.
 - Added support for Checksum on xRemoteFile - [issue #423](https://github.com/PowerShell/PSDscResources/issues/423)
 - MSFT_xRegistryResource
-  - Fixes issue that the `Set-TargetResource` does not determine the type of registry value correctly. - [issue #436](https://github.com/dsccommunity/xPSDesiredStateConfiguration/issues/436)
+  - Fixes issue that the `Set-TargetResource` does not determine
+    the type of registry value correctly.
+    [issue #436](https://github.com/dsccommunity/xPSDesiredStateConfiguration/issues/436)
 
 ## 8.10.0.0
 

--- a/DSCResources/MSFT_xRegistryResource/MSFT_xRegistryResource.psm1
+++ b/DSCResources/MSFT_xRegistryResource/MSFT_xRegistryResource.psm1
@@ -275,15 +275,33 @@ function Set-TargetResource
                 }
                 else
                 {
-                    # If the registry key value exists, check if the specified registry key value matches the retrieved registry key value
-                    if (Test-RegistryKeyValuesMatch -ExpectedRegistryKeyValue $expectedRegistryKeyValue -ActualRegistryKeyValue $actualRegistryKeyValue -RegistryKeyValueType $ValueType)
+                    # If the registry key value exists, retrieve its type
+                    $actualValueType = Get-RegistryKeyValueType -RegistryKey $registryKey -RegistryKeyValueName $ValueName
+
+                    $ShouldOverwriteRegistryKeyValue = $false
+
+                    # Check if the specified type of the registry key value matches the retrieved type of the registry key value
+                    if ($PSBoundParameters.ContainsKey('ValueType') -and ($ValueType -ne $actualValueType))
                     {
-                        # If the specified registry key value matches the retrieved registry key value, no change is needed
+                        # If the specified type of the registry key value does not matches the retrieved type of the registry key value, should overwrite the value
+                        $ShouldOverwriteRegistryKeyValue = $true
+                    }
+                    # Check if the specified registry key value matches the retrieved registry key value
+                    elseif (-not (Test-RegistryKeyValuesMatch -ExpectedRegistryKeyValue $expectedRegistryKeyValue -ActualRegistryKeyValue $actualRegistryKeyValue -RegistryKeyValueType $ValueType))
+                    {
+                        # If the specified registry key value does not matches the retrieved registry key value, should overwrite the value
+                        $ShouldOverwriteRegistryKeyValue = $true
+                    }
+
+                    # Check if the registry key value should be overwrite
+                    if ($false -eq $ShouldOverwriteRegistryKeyValue)
+                    {
+                        # No change is needed
                         Write-Verbose -Message ($script:localizedData.RegistryKeyValueAlreadySet -f $valueDisplayName, $Key)
                     }
                     else
                     {
-                        # If the specified registry key value matches the retrieved registry key value, check if the user wants to overwrite the value
+                        # Check if the user wants to overwrite the value
                         if (-not $Force)
                         {
                             # If the user does not want to overwrite the value, throw an error

--- a/Tests/Integration/MSFT_xRegistryResource.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xRegistryResource.Integration.Tests.ps1
@@ -239,7 +239,7 @@ try
                 Set-TargetResource -Key $script:registryKeyPath -ValueName $valueName -ValueData $valueData
 
                 # Verify that the registry key value has been created with the correct data and type
-                $registryValueExists = Test-RegistryValueExists -KeyPath $script:registryKeyPath -ValueName '(default)' -ValueData $valueData -ValueType 'String'
+                $registryValueExists = Test-RegistryValueExists -KeyPath $script:registryKeyPath -ValueName $valueName -ValueData $valueData -ValueType 'String'
                 $registryValueExists | Should -Be $true
             }
 
@@ -272,14 +272,14 @@ try
                 New-RegistryValue -KeyPath $script:registryKeyPath -ValueName '(default)' -ValueData $valueData -ValueType $valueType
 
                 # Verify that the registry key value exists before removal
-                $registryValueExists = Test-RegistryValueExists -KeyPath $script:registryKeyPath -ValueName '(default)'
+                $registryValueExists = Test-RegistryValueExists -KeyPath $script:registryKeyPath -ValueName $valueName
                 $registryValueExists | Should -Be $true
 
                 # Remove the registry value
                 Set-TargetResource -Key $script:registryKeyPath -ValueName $valueName -Ensure 'Absent'
 
                 # Verify that the registry key value has been removed
-                $registryValueExists = Test-RegistryValueExists -KeyPath $script:registryKeyPath -ValueName '(default)'
+                $registryValueExists = Test-RegistryValueExists -KeyPath $script:registryKeyPath -ValueName $valueName
                 $registryValueExists | Should -Be $false
             }
 
@@ -293,6 +293,23 @@ try
 
                 # Verify that the registry key value has been created with the correct data and type
                 $registryValueExists = Test-RegistryValueExists -KeyPath $registryKeyPathWithForwardSlashes -ValueName $valueName  -ValueData $valueData
+                $registryValueExists | Should -Be $true
+            }
+
+            It 'Should overwrite a existence key and value with desired value type' {
+                $valueName = 'TestValue'
+                $valueData = '123'
+                $expectedValueType = 'Dword'
+                $actualValueType = 'String'
+
+                # Create the test registry value
+                New-RegistryValue -KeyPath $script:registryKeyPath -ValueName $valueName -ValueData $valueData -ValueType $actualValueType
+
+                # Update the new registry key value
+                Set-TargetResource -Key $script:registryKeyPath -ValueName $valueName -ValueData $valueData -ValueType $expectedValueType -Force $true
+
+                # Verify that the registry key value has been updated with the correct data and type
+                $registryValueExists = Test-RegistryValueExists -KeyPath $script:registryKeyPath -ValueName $valueName -ValueData $valueData -ValueType $expectedValueType
                 $registryValueExists | Should -Be $true
             }
 
@@ -394,6 +411,19 @@ try
 
                 $testTargetResourceResult = Test-TargetResource -Key $script:registryKeyPath -ValueName $valueName -ValueData $valueData
                 $testTargetResourceResult | Should -Be $true
+            }
+
+            It 'Should return false when the specified registry value exists and matches but the type does not matches expected one' {
+                $valueName = 'TestValue'
+                $valueData = '123'
+                $expectedValueType = 'Dword'
+                $actualValueType = 'String'
+
+                # Create the test registry value
+                New-RegistryValue -KeyPath $script:registryKeyPath -ValueName $valueName -ValueData $valueData -ValueType $actualValueType
+
+                $testTargetResourceResult = Test-TargetResource -Key $script:registryKeyPath -ValueName $valueName -ValueData $valueData -ValueType $expectedValueType
+                $testTargetResourceResult | Should -Be $false
             }
         }
     }

--- a/Tests/MSFT_xRegistryResource.TestHelper.psm1
+++ b/Tests/MSFT_xRegistryResource.TestHelper.psm1
@@ -54,9 +54,11 @@ function Test-RegistryValueExists
         [System.String]
         $ValueName,
 
-        [System.String]
+        [Parameter()]
+        [System.String[]]
         $ValueData,
 
+        [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.String]
         $ValueType
@@ -64,43 +66,66 @@ function Test-RegistryValueExists
 
     try
     {
-        $registryValue = Get-ItemProperty -Path $KeyPath -Name $ValueName -ErrorAction 'SilentlyContinue'
-        Write-Verbose -Message "Test-RegistryValueExists - Registry key value: $registryKeyValue"
-
-        $registryValueExists = $null -ne $registryValue
-
-        Write-Verbose -Message "Test-RegistryValueExists - Registry value is not null: $registryValueExists"
-
-        if (-not $registryValueExists)
+        $registryKey = Get-Item -LiteralPath $KeyPath -ErrorAction 'Ignore'
+        if ($null -eq $registryKey)
         {
+            Write-Verbose -Message "Test-RegistryValueExists - Registry key is not exist"
             return $false
         }
 
-        $registryValue = $registryValue.$ValueName
+        $registryValue = $registryKey.GetValue($ValueName, $null, [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
+        if ($null -eq $registryValue)
+        {
+            Write-Verbose -Message "Test-RegistryValueExists - Registry value is not exist"
+            return $false
+        }
+
+        $registryValueType = $registryKey.GetValueKind($ValueName)
+        Write-Verbose -Message "Test-RegistryValueExists - Registry value is exist"
 
         if ($PSBoundParameters.ContainsKey('ValueType'))
         {
-            Write-Verbose -Message "Test-RegistryValueExists - Registry value type: $($registryValue.GetType().Name)"
-
-            if ($ValueType -eq 'Binary')
+            Write-Verbose -Message "Test-RegistryValueExists - Registry value type: $registryValueType"
+            if ($ValueType -ne $registryValueType)
             {
-                $registryValueExists = $registryValueExists -and ($registryValue.GetType().Name -eq 'Byte[]')
-                $registryValue = Convert-ByteArrayToHexString -Data $registryValue
-            }
-            else
-            {
-                $registryValueExists = $registryValueExists -and ($registryValue.GetType().Name -eq $ValueType)
+                return $false
             }
         }
 
         if ($PSBoundParameters.ContainsKey('ValueData'))
         {
-            Write-Verbose -Message "Test-RegistryValueExists - Registry value data: $registryValue"
+            if ($registryValueType -eq 'MultiString')
+            {
+                # Array comparison
+                if ($registryValue.Length -ne $ValueData.Length)
+                {
+                    return $false
+                }
 
-            $registryValueExists = $registryValueExists -and ($ValueData -eq $registryValue)
+                for ($i = 0; $i -lt $registryValue.Length; $i++)
+                {
+                    if ($registryValue[$i] -cne $ValueData[$i])
+                    {
+                        return $false
+                    }
+                }
+            }
+            else
+            {
+                if ($registryValueType -eq 'Binary')
+                {
+                    $registryValue = Convert-ByteArrayToHexString $registryValue
+                }
+
+                #simple value comparison
+                if ($registryValue -cne $ValueData[0])
+                {
+                    return $false
+                }
+            }
         }
 
-        return $registryValueExists
+        return $true
     }
     catch
     {

--- a/Tests/Unit/MSFT_xRegistryResource.Tests.ps1
+++ b/Tests/Unit/MSFT_xRegistryResource.Tests.ps1
@@ -1878,7 +1878,7 @@ try
                     { $null = Test-TargetResource @testTargetResourceParameters } | Should -Not -Throw
                 }
 
-                It 'Should retrieve the registry resource with the specified reigstry key and value name' {
+                It 'Should retrieve the registry resource with the specified registry key and value name' {
                     $getTargetResourceParameterFilter = {
                         $keyParameterCorrect = $Key -eq $testTargetResourceParameters.Key
                         $valueNameParameterCorrect = $ValueName -eq $testTargetResourceParameters.ValueName
@@ -1919,7 +1919,7 @@ try
                     { $null = Test-TargetResource @testTargetResourceParameters } | Should -Not -Throw
                 }
 
-                It 'Should retrieve the registry resource with the specified reigstry key and value name' {
+                It 'Should retrieve the registry resource with the specified registry key and value name' {
                     $getTargetResourceParameterFilter = {
                         $keyParameterCorrect = $Key -eq $testTargetResourceParameters.Key
                         $valueNameParameterCorrect = $ValueName -eq $testTargetResourceParameters.ValueName
@@ -1984,7 +1984,7 @@ try
                     Assert-MockCalled -CommandName 'Get-RegistryKeyValueDisplayName' -ParameterFilter $getRegistryKeyValueDisplayNameParameterFilter -Times 1 -Scope 'Context'
                 }
 
-                It 'Should retrieve the registry resource with the specified reigstry key and value name' {
+                It 'Should retrieve the registry resource with the specified registry key and value name' {
                     $getTargetResourceParameterFilter = {
                         $keyParameterCorrect = $Key -eq $testTargetResourceParameters.Key
                         $valueNameParameterCorrect = $ValueName -eq $testTargetResourceParameters.ValueName
@@ -2021,7 +2021,7 @@ try
                     { $null = Test-TargetResource @testTargetResourceParameters } | Should -Not -Throw
                 }
 
-                It 'Should retrieve the registry resource with the specified reigstry key and value name' {
+                It 'Should retrieve the registry resource with the specified registry key and value name' {
                     $getTargetResourceParameterFilter = {
                         $keyParameterCorrect = $Key -eq $testTargetResourceParameters.Key
                         $valueNameParameterCorrect = $ValueName -eq $testTargetResourceParameters.ValueName
@@ -2073,7 +2073,7 @@ try
                     { $null = Test-TargetResource @testTargetResourceParameters } | Should -Not -Throw
                 }
 
-                It 'Should retrieve the registry resource with the specified reigstry key and value name' {
+                It 'Should retrieve the registry resource with the specified registry key and value name' {
                     $getTargetResourceParameterFilter = {
                         $keyParameterCorrect = $Key -eq $testTargetResourceParameters.Key
                         $valueNameParameterCorrect = $ValueName -eq $testTargetResourceParameters.ValueName
@@ -2114,7 +2114,7 @@ try
                     { $null = Test-TargetResource @testTargetResourceParameters } | Should -Not -Throw
                 }
 
-                It 'Should retrieve the registry resource with the specified reigstry key and value name' {
+                It 'Should retrieve the registry resource with the specified registry key and value name' {
                     $getTargetResourceParameterFilter = {
                         $keyParameterCorrect = $Key -eq $testTargetResourceParameters.Key
                         $valueNameParameterCorrect = $ValueName -eq $testTargetResourceParameters.ValueName
@@ -2144,7 +2144,7 @@ try
                 }
             }
 
-            Context 'Registry key value exists, Enusre set to Absent, and registry key value name specified' {
+            Context 'Registry key value exists, Ensure set to Absent, and registry key value name specified' {
                 $testTargetResourceParameters = @{
                     Key = 'TestRegistryKey'
                     ValueName = 'TestRegistryKeyValueName'
@@ -2155,7 +2155,7 @@ try
                     { $null = Test-TargetResource @testTargetResourceParameters } | Should -Not -Throw
                 }
 
-                It 'Should retrieve the registry resource with the specified reigstry key and value name' {
+                It 'Should retrieve the registry resource with the specified registry key and value name' {
                     $getTargetResourceParameterFilter = {
                         $keyParameterCorrect = $Key -eq $testTargetResourceParameters.Key
                         $valueNameParameterCorrect = $ValueName -eq $testTargetResourceParameters.ValueName
@@ -2190,7 +2190,7 @@ try
                 }
             }
 
-            Context 'Registry key value exists, Enusre set to Absent, and registry key value type specified' {
+            Context 'Registry key value exists, Ensure set to Absent, and registry key value type specified' {
                 $testTargetResourceParameters = @{
                     Key = 'TestRegistryKey'
                     ValueName = ''
@@ -2202,7 +2202,7 @@ try
                     { $null = Test-TargetResource @testTargetResourceParameters } | Should -Not -Throw
                 }
 
-                It 'Should retrieve the registry resource with the specified reigstry key and value name' {
+                It 'Should retrieve the registry resource with the specified registry key and value name' {
                     $getTargetResourceParameterFilter = {
                         $keyParameterCorrect = $Key -eq $testTargetResourceParameters.Key
                         $valueNameParameterCorrect = $ValueName -eq $testTargetResourceParameters.ValueName
@@ -2237,7 +2237,7 @@ try
                 }
             }
 
-            Context 'Registry key value exists, Enusre set to Absent, and registry key value data specified' {
+            Context 'Registry key value exists, Ensure set to Absent, and registry key value data specified' {
                 $testTargetResourceParameters = @{
                     Key = 'TestRegistryKey'
                     ValueName = ''
@@ -2249,7 +2249,7 @@ try
                     { $null = Test-TargetResource @testTargetResourceParameters } | Should -Not -Throw
                 }
 
-                It 'Should retrieve the registry resource with the specified reigstry key and value name' {
+                It 'Should retrieve the registry resource with the specified registry key and value name' {
                     $getTargetResourceParameterFilter = {
                         $keyParameterCorrect = $Key -eq $testTargetResourceParameters.Key
                         $valueNameParameterCorrect = $ValueName -eq $testTargetResourceParameters.ValueName
@@ -2284,7 +2284,7 @@ try
                 }
             }
 
-            Context 'Registry key value exists, Enusre set to Present, and registry key value name specified' {
+            Context 'Registry key value exists, Ensure set to Present, and registry key value name specified' {
                 $testTargetResourceParameters = @{
                     Key = 'TestRegistryKey'
                     ValueName = 'TestRegistryKeyValueName'
@@ -2295,7 +2295,7 @@ try
                     { $null = Test-TargetResource @testTargetResourceParameters } | Should -Not -Throw
                 }
 
-                It 'Should retrieve the registry resource with the specified reigstry key and value name' {
+                It 'Should retrieve the registry resource with the specified registry key and value name' {
                     $getTargetResourceParameterFilter = {
                         $keyParameterCorrect = $Key -eq $testTargetResourceParameters.Key
                         $valueNameParameterCorrect = $ValueName -eq $testTargetResourceParameters.ValueName
@@ -2337,7 +2337,7 @@ try
                 }
             }
 
-            Context 'Registry key value exists, Enusre set to Present, and matching registry key value type specified' {
+            Context 'Registry key value exists, Ensure set to Present, and matching registry key value type specified' {
                 $testTargetResourceParameters = @{
                     Key = 'TestRegistryKey'
                     ValueName = ''
@@ -2349,7 +2349,7 @@ try
                     { $null = Test-TargetResource @testTargetResourceParameters } | Should -Not -Throw
                 }
 
-                It 'Should retrieve the registry resource with the specified reigstry key, value name, and value type' {
+                It 'Should retrieve the registry resource with the specified registry key, value name, and value type' {
                     $getTargetResourceParameterFilter = {
                         $keyParameterCorrect = $Key -eq $testTargetResourceParameters.Key
                         $valueNameParameterCorrect = $ValueName -eq $testTargetResourceParameters.ValueName
@@ -2393,7 +2393,7 @@ try
                 }
             }
 
-            Context 'Registry key value exists, Enusre set to Present, and matching registry key value data specified' {
+            Context 'Registry key value exists, Ensure set to Present, and matching registry key value data specified' {
                 $testTargetResourceParameters = @{
                     Key = 'TestRegistryKey'
                     ValueName = ''
@@ -2405,7 +2405,7 @@ try
                     { $null = Test-TargetResource @testTargetResourceParameters } | Should -Not -Throw
                 }
 
-                It 'Should retrieve the registry resource with the specified reigstry key, value name, and value data' {
+                It 'Should retrieve the registry resource with the specified registry key, value name, and value data' {
                     $getTargetResourceParameterFilter = {
                         $keyParameterCorrect = $Key -eq $testTargetResourceParameters.Key
                         $valueNameParameterCorrect = $ValueName -eq $testTargetResourceParameters.ValueName
@@ -2456,7 +2456,7 @@ try
                 }
             }
 
-            Context 'Registry key value exists, Enusre set to Present, and mismatching registry key value type specified' {
+            Context 'Registry key value exists, Ensure set to Present, and mismatching registry key value type specified' {
                 $testTargetResourceParameters = @{
                     Key = 'TestRegistryKey'
                     ValueName = ''
@@ -2468,7 +2468,7 @@ try
                     { $null = Test-TargetResource @testTargetResourceParameters } | Should -Not -Throw
                 }
 
-                It 'Should retrieve the registry resource with the specified reigstry key, value name, and value type' {
+                It 'Should retrieve the registry resource with the specified registry key, value name, and value type' {
                     $getTargetResourceParameterFilter = {
                         $keyParameterCorrect = $Key -eq $testTargetResourceParameters.Key
                         $valueNameParameterCorrect = $ValueName -eq $testTargetResourceParameters.ValueName
@@ -2516,7 +2516,7 @@ try
 
             Mock -CommandName 'Test-RegistryKeyValuesMatch' -MockWith { return $false }
 
-            Context 'Registry key value exists, Enusre set to Present, and mismatching registry key value data specified' {
+            Context 'Registry key value exists, Ensure set to Present, and mismatching registry key value data specified' {
                 $testTargetResourceParameters = @{
                     Key = 'TestRegistryKey'
                     ValueName = ''
@@ -2528,7 +2528,7 @@ try
                     { $null = Test-TargetResource @testTargetResourceParameters } | Should -Not -Throw
                 }
 
-                It 'Should retrieve the registry resource with the specified reigstry key, value name, and value data' {
+                It 'Should retrieve the registry resource with the specified registry key, value name, and value data' {
                     $getTargetResourceParameterFilter = {
                         $keyParameterCorrect = $Key -eq $testTargetResourceParameters.Key
                         $valueNameParameterCorrect = $ValueName -eq $testTargetResourceParameters.ValueName
@@ -2641,7 +2641,7 @@ try
                         { $null = ConvertTo-RegistryDriveName @convertToRegistryDriveNameParameters } | Should -Not -Throw
                     }
 
-                    $expcetedRegistryDriveName = switch ($validRegistryDriveRoot)
+                    $expectedRegistryDriveName = switch ($validRegistryDriveRoot)
                     {
                         'HKEY_CLASSES_ROOT' { 'HKCR' }
                         'HKEY_CURRENT_USER' { 'HKCU' }
@@ -2652,8 +2652,8 @@ try
 
                     $convertToRegistryDriveNameResult = ConvertTo-RegistryDriveName @convertToRegistryDriveNameParameters
 
-                    It "Should return correct registry drive name $expcetedRegistryDriveName" {
-                        $convertToRegistryDriveNameResult | Should -Be $expcetedRegistryDriveName
+                    It "Should return correct registry drive name $expectedRegistryDriveName" {
+                        $convertToRegistryDriveNameResult | Should -Be $expectedRegistryDriveName
                     }
                 }
             }
@@ -2838,16 +2838,16 @@ try
                 }
 
                 It 'Should retrieve the registry drive with specified name' {
-                    $getPSDriveParamterFilter = {
+                    $getPSDriveParameterFilter = {
                         $nameParameterCorrect = $Name -eq $mountRegistryDriveParameters.RegistryDriveName
                         return $nameParameterCorrect
                     }
 
-                    Assert-MockCalled -CommandName 'Get-PSDrive' -ParameterFilter $getPSDriveParamterFilter -Times 1 -Scope 'Context'
+                    Assert-MockCalled -CommandName 'Get-PSDrive' -ParameterFilter $getPSDriveParameterFilter -Times 1 -Scope 'Context'
                 }
 
                 It 'Should create the registry drive with specified name' {
-                    $newPSDriveParamterFilter = {
+                    $newPSDriveParameterFilter = {
                         $nameParameterCorrect = $Name -eq $mountRegistryDriveParameters.RegistryDriveName
                         $rootParameterCorrect = $Root -eq $expectedRegistryDriveRoot
                         $psProviderParameterCorrect = $PSProvider -eq 'Registry'
@@ -2856,7 +2856,7 @@ try
                         return $nameParameterCorrect -and $rootParameterCorrect -and $psProviderParameterCorrect -and $scopeParameterCorrect
                     }
 
-                    Assert-MockCalled -CommandName 'New-PSDrive' -ParameterFilter $newPSDriveParamterFilter -Times 1 -Scope 'Context'
+                    Assert-MockCalled -CommandName 'New-PSDrive' -ParameterFilter $newPSDriveParameterFilter -Times 1 -Scope 'Context'
                 }
 
                 It 'Should not return anything' {
@@ -2904,12 +2904,12 @@ try
                 }
 
                 It 'Should retrieve the registry drive with specified name' {
-                    $getPSDriveParamterFilter = {
+                    $getPSDriveParameterFilter = {
                         $nameParameterCorrect = $Name -eq $mountRegistryDriveParameters.RegistryDriveName
                         return $nameParameterCorrect
                     }
 
-                    Assert-MockCalled -CommandName 'Get-PSDrive' -ParameterFilter $getPSDriveParamterFilter -Times 1 -Scope 'Context'
+                    Assert-MockCalled -CommandName 'Get-PSDrive' -ParameterFilter $getPSDriveParameterFilter -Times 1 -Scope 'Context'
                 }
 
                 It 'Should not attempt to create a registry drive with specified name' {


### PR DESCRIPTION
#### This Pull Request (PR) fixes the following issues
#436

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->

- [x] Added an entry under the Unreleased section of the change log in
      CHANGELOG.md. Entry should say what was changed, and how that affects
      users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as
      appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See
      [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible). See
      [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to
      [DSC Resource Style Guidelines and Best Practices](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/xpsdesiredstateconfiguration/651)
<!-- Reviewable:end -->
