### PR TITLE
xService - Add recovery options properties

### DIFF
--- a/source/DSCResources/DSC_xServiceResource/DSC_xServiceResource.psm1
+++ b/source/DSCResources/DSC_xServiceResource/DSC_xServiceResource.psm1
@@ -78,6 +78,8 @@ function Get-TargetResource
             default { $serviceCimInstance.StartName }
         }
 
+        $serviceFailureActions = Get-ServiceFailureActions -Service $service.Name
+
         $serviceResource = @{
             Name            = $Name
             Ensure          = 'Present'
@@ -1867,4 +1869,31 @@ function Stop-ServiceWithTimeout
     Stop-Service -Name $ServiceName
     $waitTimeSpan = New-Object -TypeName 'TimeSpan' -ArgumentList (0, 0, 0, 0, $TerminateTimeout)
     Wait-ServiceStateWithTimeout -ServiceName $ServiceName -State 'Stopped' -WaitTimeSpan $waitTimeSpan
+}
+
+<#
+    .SYNOPSIS
+        Get the Failure Actions properties for a service from the registry
+    .DESCRIPTION
+        For the named service, read the registry and find its Failure Actions settings.
+    .EXAMPLE
+        PS C:\> $serviceFailureActions = Get-ServiceFailureActions -Service $service
+        Reads the failure actions from the binary data in the registry
+    .PARAMETER Service
+        The name of the service to retrieve properties for.
+#>
+
+function Get-ServiceFailureActions {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [String]
+        $Service
+    )
+    process {
+        $registryData = Get-ItemProperty HKLM:\SYSTEM\CurrentControlSet\Services\$service -Name FailureActions | Select-Object -ExpandProperty FailureActions
+
+        $binaryResetPeriod = $registryData[0..4]
+
+    }
 }

--- a/source/DSCResources/DSC_xServiceResource/en-US/DSC_xServiceResource.strings.psd1
+++ b/source/DSCResources/DSC_xServiceResource/en-US/DSC_xServiceResource.strings.psd1
@@ -37,4 +37,5 @@ ConvertFrom-StringData @'
     CannotGetAccountAccessErrorMessage = Failed to get user policy rights.
     CannotSetAccountAccessErrorMessage = Failed to set user policy rights.
     CorruptDependency = Service '{0}' has a corrupt dependency. For more information, inspect the registry value at HKLM:\\SYSTEM\\CurrentControlSet\\Services\\{0}\\DependOnService.
+    FailureActionsMustBeSpecifiedInOrder = Failure actions must be specified in order from 1 to 3.
 '@


### PR DESCRIPTION
#### Pull Request (PR) description
Implements the ability to manage service Failure Actions via the registry.

This change will add additional properties to the xService resource to specify reboot message, failure command, and all three of the Failure Actions.

#### This Pull Request (PR) fixes the following issues

- Fixes #678 

#### Task list

- [ ] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
