### PR TITLE
xArchive: Remove Invoke-NewPSDrive - Fixes #698

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Pin `Pester` module to 4.10.1 because Pester 5.0 is missing code
     coverage - Fixes [Issue #688](https://github.com/dsccommunity/xPSDesiredStateConfiguration/issues/688).
 - xArchive
-  - Removed `Invoke-NewPSDrive` function because it is no longer needed because
+  - Removed `Invoke-NewPSDrive` function because it is no longer needed as
     Pester issue has been resolved - Fixes [Issue #698](https://github.com/dsccommunity/xPSDesiredStateConfiguration/issues/698).
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     by changing `CopyDirectories` to `CopyPaths` - Fixes [Issue #687](https://github.com/dsccommunity/xPSDesiredStateConfiguration/issues/687).
   - Pin `Pester` module to 4.10.1 because Pester 5.0 is missing code
     coverage - Fixes [Issue #688](https://github.com/dsccommunity/xPSDesiredStateConfiguration/issues/688).
+- xArchive
+  - Removed `Invoke-NewPSDrive` function because it is no longer needed because
+    Pester issue has been resolved - Fixes [Issue #698](https://github.com/dsccommunity/xPSDesiredStateConfiguration/issues/698).
 
 ### Changed
 

--- a/source/DSCResources/DSC_xArchive/DSC_xArchive.psm1
+++ b/source/DSCResources/DSC_xArchive/DSC_xArchive.psm1
@@ -491,30 +491,6 @@ function New-Guid
 
 <#
     .SYNOPSIS
-        Invokes the cmdlet New-PSDrive with the specified parameters.
-        This is a wrapper function for unit testing due to a bug in Pester.
-        Issue has been filed here: https://github.com/pester/Pester/issues/728
-
-    .PARAMETER Parameters
-        A hashtable of parameters to splat to New-PSDrive.
-#>
-function Invoke-NewPSDrive
-{
-    [OutputType([System.Management.Automation.PSDriveInfo])]
-    [CmdletBinding()]
-    param
-    (
-        [Parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
-        [System.Collections.Hashtable]
-        $Parameters
-    )
-
-    return New-PSDrive @Parameters
-}
-
-<#
-    .SYNOPSIS
         Mounts a PSDrive to access the specified path with the permissions granted by the specified
         credential.
 
@@ -582,7 +558,7 @@ function Mount-PSDriveWithCredential
         try
         {
             Write-Verbose -Message ($script:localizedData.CreatingPSDrive -f $pathToPSDriveRoot, $Credential.UserName)
-            $newPSDrive = Invoke-NewPSDrive -Parameters $newPSDriveParameters
+            $newPSDrive = New-PSDrive @newPSDriveParameters
         }
         catch
         {

--- a/tests/Unit/DSC_xArchive.Tests.ps1
+++ b/tests/Unit/DSC_xArchive.Tests.ps1
@@ -1575,7 +1575,7 @@ try
             Describe 'xArchive\Mount-PSDriveWithCredential' {
                 Mock -CommandName 'Test-Path' -MockWith { return $true }
                 Mock -CommandName 'New-Guid' -MockWith { return $script:testGuid }
-                Mock -CommandName 'Invoke-NewPSDrive' -MockWith { throw 'Test error from New-PSDrive' }
+                Mock -CommandName 'New-PSDrive' -MockWith { throw 'Test error from New-PSDrive' }
 
                 Context 'When specified path is already accessible' {
                     $mountPSDriveWithCredentialParameters = @{
@@ -1601,7 +1601,7 @@ try
                     }
 
                     It 'Should not attempt to create a new PSDrive' {
-                        Assert-MockCalled -CommandName 'Invoke-NewPSDrive' -Exactly 0 -Scope 'Context'
+                        Assert-MockCalled -CommandName 'New-PSDrive' -Exactly 0 -Scope 'Context'
                     }
 
                     $mountPSDriveWithCredentialResult = Mount-PSDriveWithCredential @mountPSDriveWithCredentialParameters
@@ -1627,7 +1627,7 @@ try
                 }
 
                 $expectedPSDrive = New-MockObject -Type 'System.Management.Automation.PSDriveInfo'
-                Mock -CommandName 'Invoke-NewPSDrive' -MockWith { return $expectedPSDrive }
+                Mock -CommandName 'New-PSDrive' -MockWith { return $expectedPSDrive }
 
                 Context 'When specified path is not accessible, path contains a backslash but does not end with a backslash, and new PSDrive creation succeeds' {
                     $mountPSDriveWithCredentialParameters = @{
@@ -1656,16 +1656,16 @@ try
 
                     It 'Should create a new PSDrive' {
                         $newPSDriveParameterFilter = {
-                            $nameParameterCorrect = $Parameters.Name -eq $script:testGuid
-                            $psProviderParameterCorrect = $Parameters.PSProvider -eq 'FileSystem'
-                            $rootParameterCorrect = $Parameters.Root -eq $expectedPSDrivePath
-                            $scopeParameterCorrect = $Parameters.Scope -eq 'Script'
-                            $credentialParameterCorrect = $null -eq (Compare-Object -ReferenceObject $mountPSDriveWithCredentialParameters.Credential -DifferenceObject $Parameters.Credential)
+                            $nameParameterCorrect = $Name -eq $script:testGuid
+                            $psProviderParameterCorrect = $PSProvider -eq 'FileSystem'
+                            $rootParameterCorrect = $Root -eq $expectedPSDrivePath
+                            $scopeParameterCorrect = $Scope -eq 'Script'
+                            $credentialParameterCorrect = $null -eq (Compare-Object -ReferenceObject $mountPSDriveWithCredentialParameters.Credential -DifferenceObject $Credential)
 
                             return $nameParameterCorrect -and $psProviderParameterCorrect -and $rootParameterCorrect -and $scopeParameterCorrect -and $credentialParameterCorrect
                         }
 
-                        Assert-MockCalled -CommandName 'Invoke-NewPSDrive' -ParameterFilter $newPSDriveParameterFilter -Exactly 1 -Scope 'Context'
+                        Assert-MockCalled -CommandName 'New-PSDrive' -ParameterFilter $newPSDriveParameterFilter -Exactly 1 -Scope 'Context'
                     }
 
                     $mountPSDriveWithCredentialResult = Mount-PSDriveWithCredential @mountPSDriveWithCredentialParameters
@@ -1709,7 +1709,7 @@ try
                             return $nameParameterCorrect -and $psProviderParameterCorrect -and $rootParameterCorrect -and $scopeParameterCorrect -and $credentialParameterCorrect
                         }
 
-                        Assert-MockCalled -CommandName 'Invoke-NewPSDrive' -ParameterFilter $newPSDriveParameterFilter -Exactly 1 -Scope 'Context'
+                        Assert-MockCalled -CommandName 'New-PSDrive' -ParameterFilter $newPSDriveParameterFilter -Exactly 1 -Scope 'Context'
                     }
 
                     $mountPSDriveWithCredentialResult = Mount-PSDriveWithCredential @mountPSDriveWithCredentialParameters

--- a/tests/Unit/DSC_xArchive.Tests.ps1
+++ b/tests/Unit/DSC_xArchive.Tests.ps1
@@ -1700,11 +1700,11 @@ try
 
                     It 'Should create a new PSDrive' {
                         $newPSDriveParameterFilter = {
-                            $nameParameterCorrect = $Parameters.Name -eq $script:testGuid
-                            $psProviderParameterCorrect = $Parameters.PSProvider -eq 'FileSystem'
-                            $rootParameterCorrect = $Parameters.Root -eq $mountPSDriveWithCredentialParameters.Path
-                            $scopeParameterCorrect = $Parameters.Scope -eq 'Script'
-                            $credentialParameterCorrect = $null -eq (Compare-Object -ReferenceObject $mountPSDriveWithCredentialParameters.Credential -DifferenceObject $Parameters.Credential)
+                            $nameParameterCorrect = $Name -eq $script:testGuid
+                            $psProviderParameterCorrect = $PSProvider -eq 'FileSystem'
+                            $rootParameterCorrect = $Root -eq $mountPSDriveWithCredentialParameters.Path
+                            $scopeParameterCorrect = $Scope -eq 'Script'
+                            $credentialParameterCorrect = $null -eq (Compare-Object -ReferenceObject $mountPSDriveWithCredentialParameters.Credential -DifferenceObject $Credential)
 
                             return $nameParameterCorrect -and $psProviderParameterCorrect -and $rootParameterCorrect -and $scopeParameterCorrect -and $credentialParameterCorrect
                         }


### PR DESCRIPTION
#### Pull Request (PR) description

This PR removes `Invoke-NewPSDrive` function from xArchive because it is no longer needed - the Pester bug requiring it has been fixed.

#### This Pull Request (PR) fixes the following issues

- Fixes #698 

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

@johlju or @mhendric  - would you mind reviewing for me when you have time

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/xpsdesiredstateconfiguration/699)
<!-- Reviewable:end -->
