### PR TITLE
xGroup: Ensure group members are always returned as an array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - xArchive
   - Removed `Invoke-NewPSDrive` function because it is no longer needed as
     Pester issue has been resolved - Fixes [Issue #698](https://github.com/dsccommunity/xPSDesiredStateConfiguration/issues/698).
+- xGroup
+  - Ensure group membership is always returned as an array - Fixes [Issue #353](https://github.com/dsccommunity/xPSDesiredStateConfiguration/issues/353).
 
 ### Changed
 

--- a/source/DSCResources/DSC_xGroupResource/DSC_xGroupResource.psm1
+++ b/source/DSCResources/DSC_xGroupResource/DSC_xGroupResource.psm1
@@ -387,6 +387,11 @@ function Get-TargetResourceOnFullSKU
             $members = Get-MembersOnFullSKU -Group $group -PrincipalContextCache $principalContextCache `
                 -Credential $Credential -Disposables $disposables
 
+            if ($members -is [System.String])
+            {
+                $members = @($members)
+            }
+
             return @{
                 GroupName = $group.Name
                 Ensure = 'Present'
@@ -456,6 +461,11 @@ function Get-TargetResourceOnNanoServer
 
     # The group was found. Find the group members.
     $members = Get-MembersOnNanoServer -Group $group
+
+    if ($members -is [System.String])
+    {
+        $members = @($members)
+    }
 
     return @{
         GroupName = $group.Name

--- a/tests/Unit/DSC_xGroupResource.Tests.ps1
+++ b/tests/Unit/DSC_xGroupResource.Tests.ps1
@@ -324,7 +324,8 @@ try
             if ($script:onNanoServer)
             {
                 Context 'xGroupResource\Get-TargetResourceOnNanoServer' {
-                    $testMembers = @('User1', 'User2')
+                    $testMembersSingle = @('User1')
+                    $testMembersMultiple = @('User1', 'User2')
 
                     Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { return @() }
 
@@ -367,11 +368,11 @@ try
                         $getTargetResourceResult.Members | Should -Be $null
                     }
 
-                    It 'Should return correct hashtable values when Get-LocalGroup returns a valid, existing group with members' {
+                    It 'Should return correct hashtable values when Get-LocalGroup returns a valid, existing group with a single member' {
                         $script:testLocalGroup.Description = $script:testGroupDescription
 
                         Mock -CommandName 'Get-LocalGroup' -MockWith { return $script:testLocalGroup }
-                        Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { return $testMembers }
+                        Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { return $testMembersSingle }
 
                         $getTargetResourceResult = Get-TargetResourceOnNanoServer -GroupName $script:testGroupName
 
@@ -383,7 +384,27 @@ try
                         $getTargetResourceResult.GroupName | Should -Be $script:testGroupName
                         $getTargetResourceResult.Ensure | Should -Be 'Present'
                         $getTargetResourceResult.Description | Should -Be $script:testGroupDescription
-                        $getTargetResourceResult.Members | Should -Be $testMembers
+                        $getTargetResourceResult.Members | Should -Be $testMembersSingle
+                        $getTargetResourceResult.Members -is [System.Object[]] | Should -BeTrue
+                    }
+
+                    It 'Should return correct hashtable values when Get-LocalGroup returns a valid, existing group with multiple members' {
+                        $script:testLocalGroup.Description = $script:testGroupDescription
+
+                        Mock -CommandName 'Get-LocalGroup' -MockWith { return $script:testLocalGroup }
+                        Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { return $testMembersMultiple }
+
+                        $getTargetResourceResult = Get-TargetResourceOnNanoServer -GroupName $script:testGroupName
+
+                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group -eq $script:testLocalGroup }
+
+                        $getTargetResourceResult -is [System.Collections.Hashtable] | Should -BeTrue
+                        $getTargetResourceResult.Keys.Count | Should -Be 4
+                        $getTargetResourceResult.GroupName | Should -Be $script:testGroupName
+                        $getTargetResourceResult.Ensure | Should -Be 'Present'
+                        $getTargetResourceResult.Description | Should -Be $script:testGroupDescription
+                        $getTargetResourceResult.Members | Should -Be $testMembersMultiple
                     }
                 }
 
@@ -861,7 +882,8 @@ try
             else
             {
                 Context 'xGroupResource\Get-TargetResourceOnFullSKU' {
-                    $testMembers = @($script:testuserPrincipal1.Name, $script:testuserPrincipal2.Name)
+                    $testMembersSingle = @($script:testuserPrincipal1.Name)
+                    $testMembersMultiple = @($script:testuserPrincipal1.Name, $script:testuserPrincipal2.Name)
 
                     Mock -CommandName 'Get-Group' -MockWith { }
                     Mock -CommandName 'Get-MembersOnFullSKU' -MockWith { return @() }
@@ -898,11 +920,11 @@ try
                         $getTargetResourceResult.Members | Should -Be $null
                     }
 
-                    It 'Should return correct hashtable values when Get-Group returns a valid, existing group with members' {
+                    It 'Should return correct hashtable values when Get-Group returns a valid, existing group with a single member' {
                         $testGroup.Description = $script:testGroupDescription
 
                         Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
-                        Mock -CommandName 'Get-MembersOnFullSKU' -MockWith { return $testMembers }
+                        Mock -CommandName 'Get-MembersOnFullSKU' -MockWith { return $testMembersSingle }
 
                         $getTargetResourceResult = Get-TargetResourceOnFullSKU -GroupName $script:testGroupName
 
@@ -915,7 +937,28 @@ try
                         $getTargetResourceResult.GroupName | Should -Be $script:testGroupName
                         $getTargetResourceResult.Ensure | Should -Be 'Present'
                         $getTargetResourceResult.Description | Should -Be $script:testGroupDescription
-                        $getTargetResourceResult.Members | Should -Be $testMembers
+                        $getTargetResourceResult.Members | Should -Be $testMembersSingle
+                        $getTargetResourceResult.Members -is [System.Object[]] | Should -BeTrue
+                    }
+
+                    It 'Should return correct hashtable values when Get-Group returns a valid, existing group with multiple members' {
+                        $testGroup.Description = $script:testGroupDescription
+
+                        Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
+                        Mock -CommandName 'Get-MembersOnFullSKU' -MockWith { return $testMembersMultiple }
+
+                        $getTargetResourceResult = Get-TargetResourceOnFullSKU -GroupName $script:testGroupName
+
+                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Get-MembersOnFullSKU' -ParameterFilter { $Group -eq $script:testGroup }
+                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
+
+                        $getTargetResourceResult -is [System.Collections.Hashtable] | Should -BeTrue
+                        $getTargetResourceResult.Keys.Count | Should -Be 4
+                        $getTargetResourceResult.GroupName | Should -Be $script:testGroupName
+                        $getTargetResourceResult.Ensure | Should -Be 'Present'
+                        $getTargetResourceResult.Description | Should -Be $script:testGroupDescription
+                        $getTargetResourceResult.Members | Should -Be $testMembersMultiple
                     }
                 }
 


### PR DESCRIPTION
#### Pull Request (PR) description

PowerShell will unpack single element arrays on function return by default. That's problematic when we explicitly expect an array. This fixes issue #353 which occurs when running `Get-DscConfiguration` where the configuration has at least one `xGroup` state for a group which contains only a single member. The fix is simply to ensure an array is always returned, even if there's <2 elements.

#### This Pull Request (PR) fixes the following issues

- Fixes #353

#### Task list
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/xpsdesiredstateconfiguration/701)
<!-- Reviewable:end -->
