### PR TITLE
xPackage, fixes bug using the file hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - xPackage
-  - Fixed a bug not allowing using the file hash of an installer (#702).
+  - Fixed a bug not allowing using the file hash of an installer [Issue #702](https://github.com/dsccommunity/xPSDesiredStateConfiguration/issues/702).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ The format is based on and uses the types of changes according to [Keep a Change
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- xPSDesiredStateConfiguration
-  - xPackage
-    - Fixed a bug not allowing using the file hash of an installer (#702).
+
+- xPackage
+  - Fixed a bug not allowing using the file hash of an installer (#702).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ The format is based on and uses the types of changes according to [Keep a Change
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- xPSDesiredStateConfiguration
+  - xPackage
+    - Fixed a bug not allowing using the file hash of an installer (#702).
 
 ### Fixed
 

--- a/source/DSCResources/DSC_xPackageResource/DSC_xPackageResource.psm1
+++ b/source/DSCResources/DSC_xPackageResource/DSC_xPackageResource.psm1
@@ -1341,7 +1341,6 @@ function Assert-FileHashValid
         [System.String]
         $Path,
 
-        [Parameter()]
         [Parameter(Mandatory = $true)]
         [System.String]
         $Hash,


### PR DESCRIPTION
#### Pull Request (PR) description
When trying to install or uninstall a software package using xPackage and providing a file hash, this error is thrown:

```
PowerShell DSC resource DSC_xPackageResource  failed to execute Set-TargetResource functionality with error message: The parameter "Hash" is 
declared in parameter-set "__AllParameterSets" multiple times. 
    + CategoryInfo          : InvalidOperation: (:) [], CimException
    + FullyQualifiedErrorId : ProviderOperationExecutionFailure
    + PSComputerName        : localhost
```

#### This Pull Request (PR) fixes the following issues
- Fixes #702

#### Task list
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/xpsdesiredstateconfiguration/703)
<!-- Reviewable:end -->
