### PR TITLE
xPackage, fixes bug preventing uninstalling software

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- xPackage
+  - Uninstalling software (Ensure = Absent) did not work due to improper handling of arguments. This fixes #704.
+
 ### Fixed
 
 - xPSDesiredStateConfiguration

--- a/source/DSCResources/DSC_xPackageResource/DSC_xPackageResource.psm1
+++ b/source/DSCResources/DSC_xPackageResource/DSC_xPackageResource.psm1
@@ -539,19 +539,8 @@ function Set-TargetResource
             else
             {
                 # Absent case
-                $startInfo.FileName = "$env:winDir\system32\msiexec.exe"
-
-                # We may have used the Name earlier, now we need the actual ID
-                if ($null -eq $productEntry -or $null -eq $productEntry.Name)
-                {
-                    $id = $Path
-                }
-                else
-                {
-                    $id = Split-Path -Path $productEntry.Name -Leaf
-                }
-
-                $startInfo.Arguments = "/x `"$id`" /quiet /norestart"
+                $uninstallString = $productEntry.GetValue('UninstallString')
+                $startInfo.FileName = $uninstallString
 
                 if ($LogPath)
                 {
@@ -561,7 +550,7 @@ function Set-TargetResource
                 if ($Arguments)
                 {
                     # Append the specified arguments with a space (#195)
-                    $startInfo.Arguments += ' {0}' -f $Arguments
+                    $startInfo.Arguments = " $Arguments"
                 }
             }
         }


### PR DESCRIPTION
#### Pull Request (PR) description
Uninstalling a .exe or .msi hangs forever as the argument handling is incorrect. The Set function calls 'msiexec.exe' and adds the installation arguments to the call. As this does not work, the process hangs waiting for input.

#### This Pull Request (PR) fixes the following issues
Fixes #704.

#### Task list
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
