### PR TITLE
xGroup: support adding IIS AppPoll accounts as members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     Pester issue has been resolved - Fixes [Issue #698](https://github.com/dsccommunity/xPSDesiredStateConfiguration/issues/698).
 - xGroup
   - Ensure group membership is always returned as an array - Fixes [Issue #353](https://github.com/dsccommunity/xPSDesiredStateConfiguration/issues/353).
+  - Support adding IIS AppPool users as group members - Fixes [Issue #350](https://github.com/dsccommunity/xPSDesiredStateConfiguration/issues/350).
 
 ### Changed
 

--- a/source/DSCResources/DSC_xGroupResource/DSC_xGroupResource.psm1
+++ b/source/DSCResources/DSC_xGroupResource/DSC_xGroupResource.psm1
@@ -2409,7 +2409,8 @@ function Find-Principal
         {
             $identitySid = $ntAccount.Translate([System.Security.Principal.SecurityIdentifier])
         }
-        catch {
+        catch
+        {
             $identitySid = $null
         }
 
@@ -2418,8 +2419,8 @@ function Find-Principal
             return [System.DirectoryServices.AccountManagement.Principal]::FindByIdentity($PrincipalContext, [System.DirectoryServices.AccountManagement.IdentityType]::Sid, $identitySid.Value)
         }
         else {
-        return [System.DirectoryServices.AccountManagement.Principal]::FindByIdentity($PrincipalContext, $IdentityValue)
-    }
+            return [System.DirectoryServices.AccountManagement.Principal]::FindByIdentity($PrincipalContext, $IdentityValue)
+        }
     }
 }
 

--- a/tests/Unit/DSC_xGroupResource.Tests.ps1
+++ b/tests/Unit/DSC_xGroupResource.Tests.ps1
@@ -273,7 +273,7 @@ try
                 Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $true }
 
                 It 'Should split a member name in the domain\username format with the machine domain' {
-                    $testMemberName = 'domain\username'
+                    $testMemberName = "$script:localDomain\username"
                     $splitMemberNameResult = Split-MemberName -MemberName $testMemberName
 
                     Assert-MockCalled -CommandName 'Test-IsLocalMachine'
@@ -300,7 +300,7 @@ try
                 }
 
                 It 'Should split a member name in the CN=username,DC=domain format with local domain' {
-                    $testMemberName = 'CN=username,DC=domain'
+                    $testMemberName = "CN=username,DC=$script:localDomain"
                     $splitMemberNameResult = Split-MemberName -MemberName $testMemberName
 
                     $splitMemberNameResult | Should -Be @( $script:localDomain, $testMemberName )


### PR DESCRIPTION
<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    Please prefix the PR title with the resource name,
    e.g. 'ResourceName: My short description'.
    If this is a breaking change, then also prefix the PR title
    with 'BREAKING CHANGE:',
    e.g. 'BREAKING CHANGE: ResourceName: My short description'.

    You may remove this comment block, and the other comment blocks, but please
    keep the headers and the task list.
-->
#### Pull Request (PR) description
This is a quick attempt at adding support for IIS AppPool group members.

The approach I took is to use `[System.Security.Principal.NTAccount]` to resolve SID for local accounts for which scope name does not resolve to computer name, and use the SID to find the identity principal.

<!--
    Replace this comment block with a description of your PR.
    Also, make sure you have updated the CHANGELOG.md, see the
    task list below. An entry in the CHANGELOG.md is mandatory
    for all PRs.
-->

#### This Pull Request (PR) fixes the following issues
<!--
    If this PR does not fix an open issue, replace this comment block with None.
    If this PR resolves one or more open issues, replace this comment block with
    a list of the issues using a GitHub closing keyword, e.g.:

- Fixes #350

-->

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/xpsdesiredstateconfiguration/709)
<!-- Reviewable:end -->
