### PR TITLE
xUser, xGroup: Add NewName property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated build to use `Sampler.GitHubTasks` - Fixes [Issue #711](https://github.com/dsccommunity/xPSDesiredStateConfiguration/issues/711).
 - Added support for publishing code coverage to `CodeCov.io` and
   Azure Pipelines - Fixes [Issue #711](https://github.com/dsccommunity/xPSDesiredStateConfiguration/issues/711).
+- Added NewName property to both xUser and xGroup.
 
 ## [9.1.0] - 2020-02-19
 

--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ None
   remove a group, set this property to Absent. The default value is Present.
   { *Present* | Absent }.
 * **[String] Description** _(Write)_: The description the group should have.
+* **[String] NewName** _(Write)_: The new name the group should have. When setting this property, the GroupName property must be set appropriately to uniquely identify the group both before and after setting the SamAccountName, e.g. by SID.
 * **[String[]] Members** _(Write)_: The members the group should have. This
   property will replace all the current group members with the specified
   members. Members should be specified as strings in the format of their domain
@@ -886,6 +887,8 @@ None
   * Default Value: Present
 * **[String] FullName** _(Write)_: Represents a string with the full name you
   want to use for the user account.
+* **[String] NewName** _(Write)_: Represents a string with the new name you
+  want to use for the user account. When setting this property, the UserName property must be set appropriately to uniquely identify the user both before and after setting the SamAccountName, e.g. by SID.
 * **[PSCredential] Password** _(Write)_: Indicates the password you want to use
   for this account.
 * **[Boolean] PasswordChangeNotAllowed** _(Write)_: Indicates if the user can

--- a/source/DSCResources/DSC_xGroupResource/DSC_xGroupResource.psm1
+++ b/source/DSCResources/DSC_xGroupResource/DSC_xGroupResource.psm1
@@ -621,6 +621,15 @@ function Set-TargetResourceOnFullSKU
 
                 if (-not $groupOriginallyExists)
                 {
+                    foreach ($incompatibleParameterName in @( 'NewName' ))
+                    {
+                        if ($PSBoundParameters.ContainsKey($incompatibleParameterName))
+                        {
+                            New-InvalidArgumentException -ArgumentName $incompatibleParameterName `
+                                -Message ($script:localizedData.NewGroupNewNameConflict -f 'NewName', $incompatibleParameterName)
+                        }
+                    }
+
                     $localPrincipalContext = Get-PrincipalContext -PrincipalContextCache $principalContextCache `
                         -Disposables $disposables -Scope $env:COMPUTERNAME
 

--- a/source/DSCResources/DSC_xGroupResource/DSC_xGroupResource.psm1
+++ b/source/DSCResources/DSC_xGroupResource/DSC_xGroupResource.psm1
@@ -139,6 +139,9 @@ function Get-TargetResource
     .PARAMETER Description
         The description the group should have.
 
+    .PARAMETER NewName
+        The name the group should have.
+
     .PARAMETER Members
         The members the group should have.
 
@@ -204,6 +207,10 @@ function Set-TargetResource
         $Description,
 
         [Parameter()]
+        [System.String]
+        $NewName,
+
+        [Parameter()]
         [System.String[]]
         $Members,
 
@@ -253,6 +260,9 @@ function Set-TargetResource
 
     .PARAMETER Description
         The description of the group to test for.
+
+    .PARAMETER NewName
+        The name of the group to test for.
 
     .PARAMETER Members
         The list of members the group should have.
@@ -306,6 +316,10 @@ function Test-TargetResource
         [Parameter()]
         [System.String]
         $Description,
+
+        [Parameter()]
+        [System.String]
+        $NewName,
 
         [Parameter()]
         [System.String[]]
@@ -493,6 +507,9 @@ function Get-TargetResourceOnNanoServer
     .PARAMETER Description
         The description of the group.
 
+    .PARAMETER NewName
+        The name the group should have.
+
     .PARAMETER Members
         Use this property to replace the current group membership with the specified members.
 
@@ -548,6 +565,10 @@ function Set-TargetResourceOnFullSKU
         $Description,
 
         [Parameter()]
+        [System.String]
+        $NewName,
+
+        [Parameter()]
         [System.String[]]
         $Members,
 
@@ -596,6 +617,7 @@ function Set-TargetResourceOnFullSKU
             if ($whatIfShouldProcess)
             {
                 $saveChanges = $false
+                $needsRename = $false
 
                 if (-not $groupOriginallyExists)
                 {
@@ -616,6 +638,13 @@ function Set-TargetResourceOnFullSKU
                 {
                     $group.Description = $Description
                     $saveChanges = $true
+                }
+
+                if ($PSBoundParameters.ContainsKey('NewName') -and (($groupOriginallyExists) -and ($NewName -ne $group.SamAccountName)))
+                {
+                    $group.SamAccountName = $NewName
+                    $saveChanges = $true
+                    $needsRename = $true
                 }
 
                 $actualMembersAsPrincipals = $null
@@ -790,6 +819,13 @@ function Set-TargetResourceOnFullSKU
                 {
                     Save-Group -Group $group
 
+                    if ($needsRename)
+                    {
+                        $dirEntry = [System.DirectoryServices.DirectoryEntry]($group.GetUnderlyingObject())
+                        $dirEntry.Rename($newName);
+                        $dirEntry.CommitChanges();
+                    }
+
                     # Send an operation success verbose message.
                     if ($groupOriginallyExists)
                     {
@@ -851,6 +887,9 @@ function Set-TargetResourceOnFullSKU
     .PARAMETER Description
         The description of the group.
 
+    .PARAMETER NewName
+        The name the group should have.
+
     .PARAMETER Members
         Use this property to replace the current group membership with the specified members.
 
@@ -903,6 +942,10 @@ function Set-TargetResourceOnNanoServer
         [Parameter()]
         [System.String]
         $Description,
+
+        [Parameter()]
+        [System.String]
+        $NewName,
 
         [Parameter()]
         [System.String[]]
@@ -969,6 +1012,12 @@ function Set-TargetResourceOnNanoServer
                 ((-not $groupOriginallyExists) -or ($Description -ne $group.Description)))
             {
                 Set-LocalGroup -Name $GroupName -Description $Description
+            }
+
+            if ($PSBoundParameters.ContainsKey('NewName') -and
+                ((-not $groupOriginallyExists) -or ($NewName -ne $group.SamAccountName)))
+            {
+                Rename-LocalGroup -Sid $GroupName -NewName $NewName
             }
 
             if ($PSBoundParameters.ContainsKey('Members'))
@@ -1087,6 +1136,9 @@ function Set-TargetResourceOnNanoServer
     .PARAMETER Description
         The description of the group to test for.
 
+    .PARAMETER $NewName
+        The name of the group to test for.
+
     .PARAMETER Members
         Use this property to test if the existing membership of the group matches
         the list provided.
@@ -1144,6 +1196,10 @@ function Test-TargetResourceOnFullSKU
         $Description,
 
         [Parameter()]
+        [System.String]
+        $NewName,
+
+        [Parameter()]
         [System.String[]]
         $Members,
 
@@ -1193,6 +1249,12 @@ function Test-TargetResourceOnFullSKU
         if ($PSBoundParameters.ContainsKey('Description') -and $Description -ne $group.Description)
         {
             Write-Verbose -Message ($script:localizedData.PropertyMismatch -f 'Description', $Description, $group.Description)
+            return $false
+        }
+
+        if ($PSBoundParameters.ContainsKey('NewName') -and $NewName -ne $group.SamAccountName)
+        {
+            Write-Verbose -Message ($script:localizedData.PropertyMismatch -f 'NewName', $NewName, $group.SamAccountName)
             return $false
         }
 
@@ -1354,6 +1416,9 @@ function Test-TargetResourceOnFullSKU
     .PARAMETER Description
         The description of the group to test for.
 
+    .PARAMETER NewName
+        The name of the group to test for.
+
     .PARAMETER Members
         Use this property to test if the existing membership of the group matches
         the list provided.
@@ -1411,6 +1476,10 @@ function Test-TargetResourceOnNanoServer
         $Description,
 
         [Parameter()]
+        [System.String]
+        $NewName,
+
+        [Parameter()]
         [System.String[]]
         $Members,
 
@@ -1459,6 +1528,12 @@ function Test-TargetResourceOnNanoServer
     if ($PSBoundParameters.ContainsKey('Description') -and $Description -ne $group.Description)
     {
         Write-Verbose -Message ($script:localizedData.PropertyMismatch -f 'Description', $Description, $group.Description)
+        return $false
+    }
+
+    if ($PSBoundParameters.ContainsKey('NewName') -and $NewName -ne $group.SamAccountName)
+    {
+        Write-Verbose -Message ($script:localizedData.PropertyMismatch -f 'NewName', $NewName, $group.SamAccountName)
         return $false
     }
 

--- a/source/DSCResources/DSC_xGroupResource/DSC_xGroupResource.schema.mof
+++ b/source/DSCResources/DSC_xGroupResource/DSC_xGroupResource.schema.mof
@@ -5,6 +5,7 @@ class DSC_xGroupResource : OMI_BaseResource
   [Key, Description("The name of the group to create, modify, or remove.")] String GroupName;
   [Write, ValueMap{"Present", "Absent"}, Values{"Present", "Absent"}, Description("Indicates if the group should exist or not.")] String Ensure;
   [Write, Description("The description the group should have.")] String Description;
+  [Write, Description("Specifies the new name of the group.")] String NewName;
   [Write, Description("The members the group should have.")] String Members[];
   [Write, Description("The members the group should include.")] String MembersToInclude[];
   [Write, Description("The members the group should exclude.")] String MembersToExclude[];

--- a/source/DSCResources/DSC_xGroupResource/en-US/DSC_xGroupResource.strings.psd1
+++ b/source/DSCResources/DSC_xGroupResource/en-US/DSC_xGroupResource.strings.psd1
@@ -12,6 +12,7 @@ ConvertFrom-StringData @'
     NoConfigurationRequiredGroupDoesNotExist = Group {0} does not exist on this node. No action required.
     CouldNotFindPrincipal = Could not find a principal with the provided name {0}.
     MembersAndIncludeExcludeConflict = The {0} and {1} parameters conflict. The {0} parameter should not be used in any combination with the {1} parameter.
+    NewGroupNewNameConflict = The {0} parameter cannot be used when creating a new group.
     GroupAndMembersEmpty = Members is empty and group {0} has no members. No change to group members is needed.
     MemberIsNotALocalUser = {0} is not a local user. User's principal source is {1}.
     MemberNotValid = The group member {0} does not exist or cannot be resolved.

--- a/source/DSCResources/DSC_xUserResource/DSC_xUserResource.psm1
+++ b/source/DSCResources/DSC_xUserResource/DSC_xUserResource.psm1
@@ -472,6 +472,15 @@ function Set-TargetResourceOnFullSKU
                 if (-not $userExists)
                 {
                     # The user with the provided name does not exist so add a new user
+                    foreach ($incompatibleParameterName in @( 'NewName' ))
+                    {
+                        if ($PSBoundParameters.ContainsKey($incompatibleParameterName))
+                        {
+                            New-InvalidArgumentException -ArgumentName $incompatibleParameterName `
+                                -Message ($script:localizedData.NewUserNewNameConflict -f 'NewName', $incompatibleParameterName)
+                        }
+                    }
+
                     $user = New-Object `
                         -TypeName System.DirectoryServices.AccountManagement.UserPrincipal `
                         -ArgumentList $principalContext

--- a/source/DSCResources/DSC_xUserResource/DSC_xUserResource.schema.mof
+++ b/source/DSCResources/DSC_xUserResource/DSC_xUserResource.schema.mof
@@ -4,6 +4,7 @@ class DSC_xUserResource : OMI_BaseResource
   [Key,Description("The name of the User to Create/Modify/Delete")] String UserName;
   [Write,Description("An enumerated value that describes if the user is expected to exist on the machine"),ValueMap{"Present", "Absent"},Values{"Present", "Absent"}] String Ensure;
   [Write,Description("The display name of the user")] String FullName;
+  [Write,Description("Specifies the new name of the user")] String NewName;
   [Write,Description("A description for the user")] String Description;
   [Write,Description("The password for the user"),EmbeddedInstance("MSFT_Credential")] String Password;
   [Write,Description("Value used to disable/enable a user account")] Boolean Disabled;

--- a/source/DSCResources/DSC_xUserResource/en-US/DSC_xUserResource.strings.psd1
+++ b/source/DSCResources/DSC_xUserResource/en-US/DSC_xUserResource.strings.psd1
@@ -12,6 +12,7 @@ ConvertFrom-StringData @'
     UserRemoved = User {0} removed successfully.
     NoConfigurationRequired = User {0} exists on this node with the desired properties. No action required.
     NoConfigurationRequiredUserDoesNotExist = User {0} does not exist on this node. No action required.
+    NewUserNewNameConflict = The {0} parameter cannot be used when creating a new user.
     InvalidUserName = The name {0} cannot be used. Names may not consist entirely of periods and/or spaces, or contain these characters: {1}
     UserExists = A user with the name {0} exists.
     UserDoesNotExist = A user with the name {0} does not exist.

--- a/tests/Unit/DSC_xGroupResource.Tests.ps1
+++ b/tests/Unit/DSC_xGroupResource.Tests.ps1
@@ -41,6 +41,7 @@ try
                 $script:disposableObjects = @()
 
                 $script:testGroupName = 'TestGroup'
+                $script:testGroupName2= 'TestGroup2'
                 $script:testGroupDescription = 'A group for testing'
 
                 $script:localDomain = $env:computerName
@@ -437,6 +438,24 @@ try
                         Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
                         Assert-MockCalled -CommandName 'New-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
                         Assert-MockCalled -CommandName 'Set-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName -and $Description -eq $script:testGroupDescription }
+                    }
+
+                    It 'Should change the name of an existing group' {
+                        Set-TargetResourceOnNanoServer -GroupName $script:testGroupName `
+                                                    -NewName $script:testGroupName2
+                        #Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                        #Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $GroupName -eq $script:testGroupName2 }
+                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Sid -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Rename-LocalGroup' -ParameterFilter { $Group.Sid -eq $script:testGroupName -and $Group.NewName -eq $script:testGroupName2 }
+                    }
+
+                    It 'Should change the name of an existing group again' {
+                        Set-TargetResourceOnNanoServer -GroupName $script:testGroupName2 `
+                                                    -NewName $script:testGroupName
+                        #Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                        #Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Sid -eq $script:testGroupName2 }
+                        Assert-MockCalled -CommandName 'Rename-LocalGroup' -ParameterFilter { $Group.Sid -eq $script:testGroupName2 -and $Group.NewName -eq $script:testGroupName }
                     }
 
                     It 'Should create a group with one local member using Members' {
@@ -1088,7 +1107,25 @@ try
                         Assert-MockCalled -CommandName 'Remove-DisposableObject'
                     }
 
-                     Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
+                    Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
+
+                    It 'Should change the name of an existing group' {
+                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName `
+                                                    -NewName $script:testGroupName2
+                        Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                        #Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName2 }
+                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Group.NewName -eq $script:testGroupName2 }
+                    }
+
+                    It 'Should change the name of an existing group again' {
+                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName2 `
+                                                    -NewName $script:testGroupName
+                        Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                        #Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName2 }
+                        Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName2 -and $Group.NewName -eq $script:testGroupName }
+                    }
 
                     It 'Should add a member to an existing group with no members using Members' {
                         $testMembers = @( $script:testUserPrincipal1.Name )

--- a/tests/Unit/DSC_xUserResource.Tests.ps1
+++ b/tests/Unit/DSC_xUserResource.Tests.ps1
@@ -134,6 +134,20 @@ try
                         Test-User -UserName $script:newUserName2 | Should -BeTrue
                     }
 
+                    It 'Should rename the user' {
+                        Test-User -UserName $script:newUserName1 | Should -BeFalse
+                        Set-TargetResource -UserName $script:newUserName2 `
+                                            -NewName $script:newUserName1
+                        Test-User -UserName $script:newUserName1 | Should -BeTrue
+                    }
+
+                    It 'Should rename the user again' {
+                        Test-User -UserName $script:newUserName2 | Should -BeFalse
+                        Set-TargetResource -UserName $script:newUserName1 `
+                                            -NewName $script:newUserName2
+                        Test-User -UserName $script:newUserName2 | Should -BeTrue
+                    }
+
                     It 'Should update the user' {
                         $disabled = $false
                         $passwordNeverExpires = $true
@@ -209,6 +223,20 @@ try
 
                         It 'Should add the new user' -Skip:$script:skipMe {
                             Set-TargetResource -UserName $script:newUserName2 -Password $script:newCredential2 -Ensure 'Present'
+                            Test-User -UserName $script:newUserName2 | Should -BeTrue
+                        }
+
+                        It 'Should rename the user' -Skip:$script:skipMe {
+                            Test-User -UserName $script:newUserName1 | Should -BeFalse
+                            Set-TargetResource -UserName $script:newUserName2 `
+                                                -NewName $script:newUserName1
+                            Test-User -UserName $script:newUserName1 | Should -BeTrue
+                        }
+
+                        It 'Should rename the user again' -Skip:$script:skipMe {
+                            Test-User -UserName $script:newUserName2 | Should -BeFalse
+                            Set-TargetResource -UserName $script:newUserName1 `
+                                                -NewName $script:newUserName2
                             Test-User -UserName $script:newUserName2 | Should -BeTrue
                         }
 


### PR DESCRIPTION
#### Pull Request (PR) description
Adds optional parameter SamAccountName to User and Group resources to allow setting this property separately. This requires that GroupName be specified using something other than the SamAccountName, e.g. SID.

#### This Pull Request (PR) fixes the following issues
- See alsö dsccommunity/ActiveDirectoryDsc#655

#### Task list
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [x] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [x] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/xpsdesiredstateconfiguration/715)
<!-- Reviewable:end -->
