### PR TITLE
xUser: add NewName property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated build to use `Sampler.GitHubTasks` - Fixes [Issue #711](https://github.com/dsccommunity/xPSDesiredStateConfiguration/issues/711).
 - Added support for publishing code coverage to `CodeCov.io` and
   Azure Pipelines - Fixes [Issue #711](https://github.com/dsccommunity/xPSDesiredStateConfiguration/issues/711).
+- Added NewName property to xUser.
 
 ## [9.1.0] - 2020-02-19
 

--- a/README.md
+++ b/README.md
@@ -886,6 +886,8 @@ None
   * Default Value: Present
 * **[String] FullName** _(Write)_: Represents a string with the full name you
   want to use for the user account.
+* **[String] NewName** _(Write)_: Represents a string with the new name you
+  want to use for the user account. When setting this property, the UserName property must be set appropriately to uniquely identify the user both before and after setting the SamAccountName, e.g. by SID.
 * **[PSCredential] Password** _(Write)_: Indicates the password you want to use
   for this account.
 * **[Boolean] PasswordChangeNotAllowed** _(Write)_: Indicates if the user can

--- a/source/DSCResources/DSC_xUserResource/DSC_xUserResource.psm1
+++ b/source/DSCResources/DSC_xUserResource/DSC_xUserResource.psm1
@@ -472,6 +472,15 @@ function Set-TargetResourceOnFullSKU
                 if (-not $userExists)
                 {
                     # The user with the provided name does not exist so add a new user
+                    foreach ($incompatibleParameterName in @( 'NewName' ))
+                    {
+                        if ($PSBoundParameters.ContainsKey($incompatibleParameterName))
+                        {
+                            New-InvalidArgumentException -ArgumentName $incompatibleParameterName `
+                                -Message ($script:localizedData.NewUserNewNameConflict -f 'NewName', $incompatibleParameterName)
+                        }
+                    }
+
                     $user = New-Object `
                         -TypeName System.DirectoryServices.AccountManagement.UserPrincipal `
                         -ArgumentList $principalContext

--- a/source/DSCResources/DSC_xUserResource/DSC_xUserResource.schema.mof
+++ b/source/DSCResources/DSC_xUserResource/DSC_xUserResource.schema.mof
@@ -4,6 +4,7 @@ class DSC_xUserResource : OMI_BaseResource
   [Key,Description("The name of the User to Create/Modify/Delete")] String UserName;
   [Write,Description("An enumerated value that describes if the user is expected to exist on the machine"),ValueMap{"Present", "Absent"},Values{"Present", "Absent"}] String Ensure;
   [Write,Description("The display name of the user")] String FullName;
+  [Write,Description("Specifies the new name of the user")] String NewName;
   [Write,Description("A description for the user")] String Description;
   [Write,Description("The password for the user"),EmbeddedInstance("MSFT_Credential")] String Password;
   [Write,Description("Value used to disable/enable a user account")] Boolean Disabled;

--- a/source/DSCResources/DSC_xUserResource/en-US/DSC_xUserResource.strings.psd1
+++ b/source/DSCResources/DSC_xUserResource/en-US/DSC_xUserResource.strings.psd1
@@ -12,6 +12,7 @@ ConvertFrom-StringData @'
     UserRemoved = User {0} removed successfully.
     NoConfigurationRequired = User {0} exists on this node with the desired properties. No action required.
     NoConfigurationRequiredUserDoesNotExist = User {0} does not exist on this node. No action required.
+    NewUserNewNameConflict = The {0} parameter cannot be used when creating a new user.
     InvalidUserName = The name {0} cannot be used. Names may not consist entirely of periods and/or spaces, or contain these characters: {1}
     UserExists = A user with the name {0} exists.
     UserDoesNotExist = A user with the name {0} does not exist.

--- a/tests/Unit/DSC_xUserResource.Tests.ps1
+++ b/tests/Unit/DSC_xUserResource.Tests.ps1
@@ -120,6 +120,7 @@ try
                     }
 
                     Mock -CommandName Test-IsNanoServer -MockWith { return $false }
+                    #Mock -CommandName New-Object
 
                     New-User -Credential $script:newCredential1 -Description $script:newUserDescription1
 

--- a/tests/Unit/DSC_xUserResource.Tests.ps1
+++ b/tests/Unit/DSC_xUserResource.Tests.ps1
@@ -134,6 +134,20 @@ try
                         Test-User -UserName $script:newUserName2 | Should -BeTrue
                     }
 
+                    It 'Should rename the user' {
+                        Test-User -UserName $script:newUserName1 | Should -BeFalse
+                        Set-TargetResource -UserName $script:newUserName2 `
+                                            -NewName $script:newUserName1
+                        Test-User -UserName $script:newUserName1 | Should -BeTrue
+                    }
+
+                    It 'Should rename the user again' {
+                        Test-User -UserName $script:newUserName2 | Should -BeFalse
+                        Set-TargetResource -UserName $script:newUserName1 `
+                                            -NewName $script:newUserName2
+                        Test-User -UserName $script:newUserName2 | Should -BeTrue
+                    }
+
                     It 'Should update the user' {
                         $disabled = $false
                         $passwordNeverExpires = $true
@@ -209,6 +223,20 @@ try
 
                         It 'Should add the new user' -Skip:$script:skipMe {
                             Set-TargetResource -UserName $script:newUserName2 -Password $script:newCredential2 -Ensure 'Present'
+                            Test-User -UserName $script:newUserName2 | Should -BeTrue
+                        }
+
+                        It 'Should rename the user' -Skip:$script:skipMe {
+                            Test-User -UserName $script:newUserName1 | Should -BeFalse
+                            Set-TargetResource -UserName $script:newUserName2 `
+                                                -NewName $script:newUserName1
+                            Test-User -UserName $script:newUserName1 | Should -BeTrue
+                        }
+
+                        It 'Should rename the user again' -Skip:$script:skipMe {
+                            Test-User -UserName $script:newUserName2 | Should -BeFalse
+                            Set-TargetResource -UserName $script:newUserName1 `
+                                                -NewName $script:newUserName2
                             Test-User -UserName $script:newUserName2 | Should -BeTrue
                         }
 


### PR DESCRIPTION
#### Pull Request (PR) description
Adds optional parameter NewName to User resource to allow setting SamAccountName property separately. This requires that UserName be specified using something other than the SamAccountName, e.g. SID.

#### This Pull Request (PR) fixes the following issues
- See alsö dsccommunity/ActiveDirectoryDsc#655

#### Task list
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [x] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [x] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/xpsdesiredstateconfiguration/719)
<!-- Reviewable:end -->
