### PR TITLE
xService: Fix Get-TargetResource always returning all user type as builtInAccount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- xService
+  - Fixed user type returned by Get-TargetResource [Issue #759](https://github.com/dsccommunity/xPSDesiredStateConfiguration/issues/759)
+
+
 ## [9.2.1] - 2024-11-11
 
 ### Fixed

--- a/source/DSCResources/DSC_xServiceResource/DSC_xServiceResource.psm1
+++ b/source/DSCResources/DSC_xServiceResource/DSC_xServiceResource.psm1
@@ -632,9 +632,10 @@ function Test-TargetResource
         {
             $expectedStartName = ConvertTo-StartName -Username $Credential.UserName
 
-            # Check that credential resource exist and that the username matches the expected start name
+            # Check that credential resource exist
             if ($serviceResource.Credential)
             {
+                # Check that the username matches the expected start name
                 if ($serviceResource.Credential.UserName -ine $expectedStartName)
                 {
                     Write-Verbose -Message ($script:localizedData.ServiceCredentialDoesNotMatch -f $Name, $Credential.UserName, $serviceResource.Credential.UserName)

--- a/source/DSCResources/DSC_xServiceResource/DSC_xServiceResource.psm1
+++ b/source/DSCResources/DSC_xServiceResource/DSC_xServiceResource.psm1
@@ -79,6 +79,11 @@ function Get-TargetResource
             default { $serviceCimInstance.StartName }
         }
 
+        # Initialize variables
+        $builtInAccount = $null
+        $GroupManagedServiceAccount = $null
+        $Credential = $null
+
         # Evaluate user type only based on the format of the string (as stated in the note)
         if (($serviceAccount -eq 'LocalSystem') -or ($serviceAccount -eq 'LocalService') -or ($serviceAccount -eq 'NetworkService'))
         {
@@ -91,7 +96,7 @@ function Get-TargetResource
         else
         {
             # Password cannot be null
-            $Password = ConvertTo-SecureString '' -AsPlainText -Force
+            $Password = ConvertTo-SecureString 'DummyPassword' -AsPlainText -Force
             $Credential = New-Object System.Management.Automation.PSCredential($serviceAccount, $Password)
         }
 

--- a/source/DSCResources/DSC_xServiceResource/DSC_xServiceResource.psm1
+++ b/source/DSCResources/DSC_xServiceResource/DSC_xServiceResource.psm1
@@ -632,7 +632,7 @@ function Test-TargetResource
         {
             $expectedStartName = ConvertTo-StartName -Username $Credential.UserName
 
-            if ($serviceResource.BuiltInAccount -ine $expectedStartName)
+            if ($serviceResource.Credential.UserName -ine $expectedStartName)
             {
                 Write-Verbose -Message ($script:localizedData.ServiceCredentialDoesNotMatch -f $Name, $Credential.UserName, $serviceResource.BuiltInAccount)
                 return $false

--- a/source/DSCResources/DSC_xServiceResource/DSC_xServiceResource.psm1
+++ b/source/DSCResources/DSC_xServiceResource/DSC_xServiceResource.psm1
@@ -89,7 +89,7 @@ function Get-TargetResource
         {
             $builtInAccount = $serviceAccount
         }
-        elseif ($serviceAccount -match '^[a-zA-Z0-9]+\\[a-zA-Z0-9]+\$$')
+        elseif ($serviceAccount -match '^[\w-]+\\[\w-]+\$$')
         {
             $GroupManagedServiceAccount = $serviceAccount
         }

--- a/source/DSCResources/DSC_xServiceResource/DSC_xServiceResource.psm1
+++ b/source/DSCResources/DSC_xServiceResource/DSC_xServiceResource.psm1
@@ -622,9 +622,9 @@ function Test-TargetResource
         {
             $expectedStartName = ConvertTo-StartName -Username $GroupManagedServiceAccount
 
-            if ($serviceResource.BuiltInAccount -ine $expectedStartName)
+            if ($serviceResource.GroupManagedServiceAccount -ine $expectedStartName)
             {
-                Write-Verbose -Message ($script:localizedData.GroupManagedServiceCredentialDoesNotMatch -f $Name, $GroupManagedServiceAccount, $serviceResource.BuiltInAccount)
+                Write-Verbose -Message ($script:localizedData.GroupManagedServiceCredentialDoesNotMatch -f $Name, $GroupManagedServiceAccount, $serviceResource.GroupManagedServiceAccount)
                 return $false
             }
         }
@@ -633,7 +633,11 @@ function Test-TargetResource
             $expectedStartName = ConvertTo-StartName -Username $Credential.UserName
 
             # Check that credential resource exist
-            if ($serviceResource.Credential)
+            if ($null -eq $serviceResource.Credential)
+            {
+                Write-Verbose -Message ($script:localizedData.ServiceCredentialIsEmpty -f $Name, $Credential.UserName)
+                return $false
+            } else 
             {
                 # Check that the username matches the expected start name
                 if ($serviceResource.Credential.UserName -ine $expectedStartName)
@@ -641,10 +645,6 @@ function Test-TargetResource
                     Write-Verbose -Message ($script:localizedData.ServiceCredentialDoesNotMatch -f $Name, $Credential.UserName, $serviceResource.Credential.UserName)
                     return $false
                 }
-            } else 
-            {
-                Write-Verbose -Message ($script:localizedData.ServiceCredentialIsEmpty -f $Name, $Credential.UserName)
-                return $false
             }
         }
 

--- a/source/DSCResources/DSC_xServiceResource/DSC_xServiceResource.psm1
+++ b/source/DSCResources/DSC_xServiceResource/DSC_xServiceResource.psm1
@@ -632,9 +632,17 @@ function Test-TargetResource
         {
             $expectedStartName = ConvertTo-StartName -Username $Credential.UserName
 
-            if ($serviceResource.Credential.UserName -ine $expectedStartName)
+            # Check that credential resource exist and that the username matches the expected start name
+            if ($serviceResource.Credential)
             {
-                Write-Verbose -Message ($script:localizedData.ServiceCredentialDoesNotMatch -f $Name, $Credential.UserName, $serviceResource.BuiltInAccount)
+                if ($serviceResource.Credential.UserName -ine $expectedStartName)
+                {
+                    Write-Verbose -Message ($script:localizedData.ServiceCredentialDoesNotMatch -f $Name, $Credential.UserName, $serviceResource.Credential.UserName)
+                    return $false
+                }
+            } else 
+            {
+                Write-Verbose -Message ($script:localizedData.ServiceCredentialIsEmpty -f $Name, $Credential.UserName)
                 return $false
             }
         }

--- a/source/DSCResources/DSC_xServiceResource/en-US/DSC_xServiceResource.strings.psd1
+++ b/source/DSCResources/DSC_xServiceResource/en-US/DSC_xServiceResource.strings.psd1
@@ -20,8 +20,8 @@ ConvertFrom-StringData @'
     ServiceStartupTypeMatches = The start mode of service {0} matches the expected start mode.
     ServiceStartupTypeDoesNotMatch = The start mode of service {0} does not match the expected start mode.
     ServicePropertyDoesNotMatch = The service property {0} of service {1} does not match the expected value. The expected value is {2}. The actual value is {3}.
-    ServiceCredentialDoesNotMatch = The start name of service {0} does not match the expected username from the given credential. The expected value is {1}. The actual value is {2}.
     ServiceCredentialIsEmpty = The start name of service {0} does not match the expected username from the given credential. The expected value is {1}. The actual value is empty.
+    ServiceCredentialDoesNotMatch = The start name of service {0} does not match the expected username from the given credential. The expected value is {1}. The actual value is {2}.
     GroupManagedServiceCredentialDoesNotMatch = The start name of service {0} does not match the expected username from the given Group Managed Service Account. The expected value is {1}. The actual value is {2}.
     ServiceDeletionSucceeded = The service {0} has been successfully deleted.
     ServiceDeletionFailed = Failed to delete service {0}.

--- a/source/DSCResources/DSC_xServiceResource/en-US/DSC_xServiceResource.strings.psd1
+++ b/source/DSCResources/DSC_xServiceResource/en-US/DSC_xServiceResource.strings.psd1
@@ -21,6 +21,7 @@ ConvertFrom-StringData @'
     ServiceStartupTypeDoesNotMatch = The start mode of service {0} does not match the expected start mode.
     ServicePropertyDoesNotMatch = The service property {0} of service {1} does not match the expected value. The expected value is {2}. The actual value is {3}.
     ServiceCredentialDoesNotMatch = The start name of service {0} does not match the expected username from the given credential. The expected value is {1}. The actual value is {2}.
+    ServiceCredentialIsEmpty = The start name of service {0} does not match the expected username from the given credential. The expected value is {1}. The actual value is empty.
     GroupManagedServiceCredentialDoesNotMatch = The start name of service {0} does not match the expected username from the given Group Managed Service Account. The expected value is {1}. The actual value is {2}.
     ServiceDeletionSucceeded = The service {0} has been successfully deleted.
     ServiceDeletionFailed = Failed to delete service {0}.

--- a/tests/Unit/DSC_xServiceResource.Tests.ps1
+++ b/tests/Unit/DSC_xServiceResource.Tests.ps1
@@ -272,16 +272,16 @@ try
                     Test-GetTargetResourceDoesntThrow -GetTargetResourceParameters $getTargetResourceParameters -TestServiceCimInstance $testServiceCimInstance
 
                     $expectedValues = @{
-                        Name                = $getTargetResourceParameters.Name
-                        Ensure              = 'Present'
-                        Path                = $testServiceCimInstance.PathName
-                        StartupType         = $convertToStartupTypeStringResult
-                        Credential.Username = $testService.StartName
-                        State               = $testService.Status
-                        DisplayName         = $testService.DisplayName
-                        Description         = $testServiceCimInstance.Description
-                        DesktopInteract     = $testServiceCimInstance.DesktopInteract
-                        Dependencies        = [System.Object[]] $testService.ServicesDependedOn.Name
+                        Name            = $getTargetResourceParameters.Name
+                        Ensure          = 'Present'
+                        Path            = $testServiceCimInstance.PathName
+                        StartupType     = $convertToStartupTypeStringResult
+                        Credential      = New-Object PSCredential $testServiceCimInstance.StartName, (ConvertTo-SecureString 'DummyPassword' -AsPlainText -Force)
+                        State           = $testService.Status
+                        DisplayName     = $testService.DisplayName
+                        Description     = $testServiceCimInstance.Description
+                        DesktopInteract = $testServiceCimInstance.DesktopInteract
+                        Dependencies    = [System.Object[]] $testService.ServicesDependedOn.Name
                     }
 
                     Test-GetTargetResourceResult -GetTargetResourceParameters $getTargetResourceParameters -ExpectedValues $expectedValues

--- a/tests/Unit/DSC_xServiceResource.Tests.ps1
+++ b/tests/Unit/DSC_xServiceResource.Tests.ps1
@@ -281,7 +281,7 @@ try
                         Ensure          = 'Present'
                         Path            = $testServiceCimInstance.PathName
                         StartupType     = $convertToStartupTypeStringResult
-                        Credential      = $testServiceCredential.Username
+                        Credential      = $testServiceCredential
                         State           = $testService.Status
                         DisplayName     = $testService.DisplayName
                         Description     = $testServiceCimInstance.Description

--- a/tests/Unit/DSC_xServiceResource.Tests.ps1
+++ b/tests/Unit/DSC_xServiceResource.Tests.ps1
@@ -271,22 +271,17 @@ try
 
                     Test-GetTargetResourceDoesntThrow -GetTargetResourceParameters $getTargetResourceParameters -TestServiceCimInstance $testServiceCimInstance
 
-                    # Password cannot be null
-                    $Password = ConvertTo-SecureString 'DummyPassword' -AsPlainText -Force
-                    # Create a PSCredential object for the custom startup account
-                    $testServiceCredential = New-Object System.Management.Automation.PSCredential($testServiceCimInstance.StartName, $Password)
-
                     $expectedValues = @{
-                        Name            = $getTargetResourceParameters.Name
-                        Ensure          = 'Present'
-                        Path            = $testServiceCimInstance.PathName
-                        StartupType     = $convertToStartupTypeStringResult
-                        Credential      = $testServiceCredential
-                        State           = $testService.Status
-                        DisplayName     = $testService.DisplayName
-                        Description     = $testServiceCimInstance.Description
-                        DesktopInteract = $testServiceCimInstance.DesktopInteract
-                        Dependencies    = [System.Object[]] $testService.ServicesDependedOn.Name
+                        Name                = $getTargetResourceParameters.Name
+                        Ensure              = 'Present'
+                        Path                = $testServiceCimInstance.PathName
+                        StartupType         = $convertToStartupTypeStringResult
+                        Credential.Username = $testService.StartName
+                        State               = $testService.Status
+                        DisplayName         = $testService.DisplayName
+                        Description         = $testServiceCimInstance.Description
+                        DesktopInteract     = $testServiceCimInstance.DesktopInteract
+                        Dependencies        = [System.Object[]] $testService.ServicesDependedOn.Name
                     }
 
                     Test-GetTargetResourceResult -GetTargetResourceParameters $getTargetResourceParameters -ExpectedValues $expectedValues

--- a/tests/Unit/DSC_xServiceResource.Tests.ps1
+++ b/tests/Unit/DSC_xServiceResource.Tests.ps1
@@ -271,12 +271,17 @@ try
 
                     Test-GetTargetResourceDoesntThrow -GetTargetResourceParameters $getTargetResourceParameters -TestServiceCimInstance $testServiceCimInstance
 
+                    # Password cannot be null
+                    $Password = ConvertTo-SecureString 'DummyPassword' -AsPlainText -Force
+                    # Create a PSCredential object for the custom startup account
+                    $testServiceCredential = New-Object System.Management.Automation.PSCredential($testServiceCimInstance.StartName, $Password)
+
                     $expectedValues = @{
                         Name            = $getTargetResourceParameters.Name
                         Ensure          = 'Present'
                         Path            = $testServiceCimInstance.PathName
                         StartupType     = $convertToStartupTypeStringResult
-                        BuiltInAccount  = $testServiceCimInstance.StartName
+                        Credential      = $testServiceCredential.Username
                         State           = $testService.Status
                         DisplayName     = $testService.DisplayName
                         Description     = $testServiceCimInstance.Description

--- a/tests/Unit/DSC_xServiceResource.Tests.ps1
+++ b/tests/Unit/DSC_xServiceResource.Tests.ps1
@@ -1446,7 +1446,7 @@ try
                     Name            = $script:testServiceName
                     Ensure          = 'Present'
                     State           = 'Running'
-                    BuiltInAccount  = $script:testCredential1.UserName
+                    Credential      = $script:testCredential1
                     DisplayName     = 'TestDisplayName'
                     Description     = 'Test service description'
                     Dependencies    = @( 'TestServiceDependency1', 'TestServiceDependency2' )
@@ -1678,13 +1678,13 @@ try
                 }
 
                 $serviceResourceWithGroupManagedServiceAccount = @{
-                    Name            = $script:testServiceName
-                    Ensure          = 'Present'
-                    State           = 'Running'
-                    BuiltInAccount  = $script:gMSAUser1
-                    DisplayName     = 'TestDisplayName'
-                    Description     = 'Test service description'
-                    Dependencies    = @( 'TestServiceDependency1', 'TestServiceDependency2' )
+                    Name                       = $script:testServiceName
+                    Ensure                     = 'Present'
+                    State                      = 'Running'
+                    GroupManagedServiceAccount = $script:gMSAUser1
+                    DisplayName                = 'TestDisplayName'
+                    Description                = 'Test service description'
+                    Dependencies               = @( 'TestServiceDependency1', 'TestServiceDependency2' )
                 }
 
                 Mock -CommandName 'Get-TargetResource' -MockWith { return $serviceResourceWithGroupManagedServiceAccount }


### PR DESCRIPTION
<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    Please prefix the PR title with the resource name,
    e.g. 'ResourceName: My short description'.
    If this is a breaking change, then also prefix the PR title
    with 'BREAKING CHANGE:',
    e.g. 'BREAKING CHANGE: ResourceName: My short description'.

    You may remove this comment block, and the other comment blocks, but please
    keep the headers and the task list.
-->

#### Pull Request (PR) description
Current xService resource always return user running the service as builtInAccount
Evaluating of type was not done to avoid call to AD to determine if user running the service is a gMSA
Evaluation is now done based on format as gMSA is always structured in the same format contoso\mygmsauser$
<!--
    Replace this comment block with a description of your PR.
    Also, make sure you have updated the CHANGELOG.md, see the
    task list below. An entry in the CHANGELOG.md is mandatory
    for all PRs.
-->

#### This Pull Request (PR) fixes the following issues

<!--
    If this PR does not fix an open issue, replace this comment block with None.
    If this PR resolves one or more open issues, replace this comment block with
    a list of the issues using a GitHub closing keyword, e.g.:

- Fixes #123
- Fixes #124
-->
Fixes #759 
#### Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->

- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [x] Resource documentation added/updated in README.md.
- [x] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [x] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/xPSDesiredStateConfiguration/776)
<!-- Reviewable:end -->
